### PR TITLE
Fix GUROBI status map

### DIFF
--- a/R/conic_solvers.R
+++ b/R/conic_solvers.R
@@ -1726,7 +1726,7 @@ setMethod("import_solver", "GUROBI_CONIC", function(solver) { requireNamespace("
 #' @param status A status code returned by the solver.
 #' @describeIn GUROBI_CONIC Converts status returned by the GUROBI solver to its respective CVXPY status.
 setMethod("status_map", "GUROBI_CONIC", function(solver, status) {
-    if(status == 2 || status == "OPTIMAL")
+  if(status == 2 || status == "OPTIMAL")
     OPTIMAL
   else if(status == 3 || status == 6 || status == "INFEASIBLE") #DK: I added the words because the GUROBI solver seems to return the words
     INFEASIBLE
@@ -1734,10 +1734,10 @@ setMethod("status_map", "GUROBI_CONIC", function(solver, status) {
     UNBOUNDED
   else if(status == 4 | status == "INF_OR_UNBD")
     INFEASIBLE_INACCURATE
-  else if(status %in% c(7,8,9,10,11,12))
+  else if(status %in% c(11,12) || status %in% c("INTERRUPTED", "NUMERIC"))
     SOLVER_ERROR   # TODO: Could be anything
-  else if(status == 13)
-    OPTIMAL_INACCURATE   # Means time expired.
+  else if(status %in% c(7,8,9,10,13) || status %in% c("ITERATION_LIMIT", "NODE_LIMIT", "TIME_LIMIT", "SOLUTION_LIMIT", "SUBOPTIMAL"))
+    OPTIMAL_INACCURATE   # user limit exceeded (but suboptimal solution may still exist) or known to be suboptimal
   else
     stop("GUROBI status unrecognized: ", status)
 })

--- a/R/qp_solvers.R
+++ b/R/qp_solvers.R
@@ -340,10 +340,10 @@ setMethod("status_map", "GUROBI_QP", function(solver, status) {
     UNBOUNDED
   else if(status == 4 | status == "INF_OR_UNBD")
     INFEASIBLE_INACCURATE
-  else if(status %in% c(7,8,9,10,11,12))
+  else if(status %in% c(11,12) || status %in% c("INTERRUPTED", "NUMERIC"))
     SOLVER_ERROR   # TODO: Could be anything
-  else if(status == 13)
-    OPTIMAL_INACCURATE   # Means time expired.
+  else if(status %in% c(7,8,9,10,13) || status %in% c("ITERATION_LIMIT", "NODE_LIMIT", "TIME_LIMIT", "SOLUTION_LIMIT", "SUBOPTIMAL"))
+    OPTIMAL_INACCURATE   # user limit exceeded (but suboptimal solution may still exist) or known to be suboptimal
   else
     stop("GUROBI status unrecognized: ", status)
 })


### PR DESCRIPTION
Fixes issue #99 

Looking at the Gurobi docs, there are status codes which indicate user limits reached. It appears to me suboptimal solution may and often exist in these cases. https://www.gurobi.com/documentation/6.5/refman/optimization_status_codes.html#sec:StatusCodes

I played around with these Gurobi user limits, and indeed when time, iteration and solution limits are hit (in my single test case of a mixed integer programming problem), suboptimal solutions are returned from Gurobi solver, and can be successfully unpacked by CVXR.

I suggest we relax what CVXR considers suboptimal solutions to include these user limit solutions. I made the change for GUROBI_CONIC as well, though I didn't bother testing that.

I did not use USER_LIMIT for these user limits status codes because USER_LIMIT is not included in SOLUTION_PRESENT, which would have caused no solution unpacking. I'm not sure if it's wise to add USER_LIMIT to SOLUTION_PRESENT, so I did not use USER_LIMIT.