### PR TITLE
Matrix 1.5 fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -101,7 +101,7 @@ Collate:
     'CVXcanon-R6.R'
     'Deque.R'
     'canonInterface.R'
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Encoding: UTF-8
 Enhances: 
     Rcplex,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CVXR
 Type: Package
 Title: Disciplined Convex Optimization
-Version: 1.0-10
+Version: 1.0-11
 VignetteBuilder: knitr
 Authors@R: c(
            person("Anqi", "Fu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# CVXR 1.0-11
+
+* Being more careful about coercing to `dgCMatrix`
+  via `(as(as(<matrix>, "CsparseMatrix"), "generalMatrix"))`
+
 # CVXR 1.0-10
 
 * Now requiring the updated scs 3.0 as an import

--- a/R/complex2real.R
+++ b/R/complex2real.R
@@ -33,7 +33,7 @@ setMethod("perform", signature(object = "Complex2Real", problem = "Problem"), fu
 
   constrs <- list()
   for(constraint in problem@constraints) {
-    if(class(constraint) == "EqConstraint")
+    if(inherits(constraint, "EqConstraint"))
       constraint <- lower_equality(constraint)
     constr <- Complex2Real.canonicalize_tree(constraint, inverse_data@real2imag, leaf_map)
     real_constr <- constr[[1]]
@@ -111,7 +111,7 @@ setMethod("invert", signature(object = "Complex2Real", solution = "Solution", in
 #' in the tree.
 Complex2Real.canonicalize_tree <- function(expr, real2imag, leaf_map) {
   # TODO: Don't copy affine expressions?
-  if(class(expr) == "PartialProblem")
+  if(inherits(expr, "PartialProblem"))
     stop("Unimplemented")
   else {
     real_args <- list()

--- a/R/complex2real.R
+++ b/R/complex2real.R
@@ -136,7 +136,7 @@ Complex2Real.canonicalize_tree <- function(expr, real2imag, leaf_map) {
 #' @param leaf_map A map that consists of a tree representation of the overall expression
 #' @return A list of the parsed out real and imaginary components of the expression at hand.
 Complex2Real.canonicalize_expr <- function(expr, real_args, imag_args, real2imag, leaf_map) {
-  if(class(expr) %in% names(Complex2Real.CANON_METHODS)) {
+  if(inherits(expr, names(Complex2Real.CANON_METHODS))) {
     expr_id <- as.character(id(expr))
     # Only canonicalize a variable/constant/parameter once.
     if(length(expr@args) == 0 && expr_id %in% names(leaf_map))

--- a/R/conic_solvers.R
+++ b/R/conic_solvers.R
@@ -612,7 +612,9 @@ setMethod("solve_via_data", "SCS", function(object, data, warm_start, verbose, f
   A  <- data[[A_KEY]]
   ## Fix for Matrix version 1.3
   ## if (inherits(A, "dsCMatrix")) A <- as(A, "dgCMatrix")
-  if (!inherits(A, "dgCMatrix")) A  <- as(as(A, "CsparseMatrix"), "dgCMatrix")
+  ## if (!inherits(A, "dgCMatrix")) A  <- as(as(A, "CsparseMatrix"), "dgCMatrix")
+  ## Matrix 1.5 change!
+  if (!inherits(A, "dgCMatrix")) A  <- as(as(A, "CsparseMatrix"), "generalMatrix")
 
   args <- list(A = A, b = data[[B_KEY]], c = data[[C_KEY]])
   if(warm_start && !is.null(solver_cache) && length(solver_cache) > 0 && name(object) %in% names(solver_cache)) {
@@ -2371,7 +2373,9 @@ setMethod("solve_via_data", "MOSEK", function(object, data, warm_start, verbose,
 
 
   ##G should already be sparse but Matrix 1.3.x causes problems.
-  if (!inherits(G, "dgCMatrix")) G  <- as(as(G, "CsparseMatrix"), "dgCMatrix")
+  ## if (!inherits(G, "dgCMatrix")) G  <- as(as(G, "CsparseMatrix"), "dgCMatrix")
+  ## Matrix 1.5 change
+  if (!inherits(G, "dgCMatrix")) G  <- as(as(G, "CsparseMatrix"), "generalMatrix")
 
   G_sum <- summary(G)
   nrow_G_sparse <- nrow(G)

--- a/R/dcp2cone.R
+++ b/R/dcp2cone.R
@@ -16,7 +16,7 @@ setMethod("initialize", "Dcp2Cone", function(.Object, ...) {
 #' @param problem A \linkS4class{Problem} object.
 #' @describeIn Dcp2Cone A problem is accepted if it is a minimization and is DCP.
 setMethod("accepts", signature(object = "Dcp2Cone", problem = "Problem"), function(object, problem) {
-  class(problem@objective) == "Minimize" && is_dcp(problem)
+  inherits(problem@objective, "Minimize") && is_dcp(problem)
 })
 
 #' @describeIn Dcp2Cone Converts a DCP problem to a conic form.
@@ -44,7 +44,7 @@ ConeMatrixStuffing <- setClass("ConeMatrixStuffing", contains = "MatrixStuffing"
 #' @param problem A \linkS4class{Problem} object.
 #' @describeIn ConeMatrixStuffing Is the solver accepted?
 setMethod("accepts", signature(object = "ConeMatrixStuffing", problem = "Problem"), function(object, problem) {
- return(class(problem@objective) == "Minimize" &&
+ return(inherits(problem@objective, "Minimize") &&
         is_affine(expr(problem@objective)) &&
         length(convex_attributes(variables(problem))) == 0 &&
         are_args_affine(problem@constraints))

--- a/R/dgp2dcp.R
+++ b/R/dgp2dcp.R
@@ -31,7 +31,7 @@ setMethod("perform", signature(object = "Dgp2Dcp", problem = "Problem"), functio
 #' @param args A list of values corresponding to the DGP expression
 #' @describeIn Dgp2Dcp Canonicalizes each atom within an Dgp2Dcp expression.
 setMethod("canonicalize_expr", "Dgp2Dcp", function(object, expr, args) {
-  if(class(expr) %in% names(object@canon_methods))
+  if(inherits(expr, names(object@canon_methods)))
     return(object@canon_methods[[class(expr)]](expr, args))
   else
     return(list(copy(expr, args), list()))

--- a/R/problem.R
+++ b/R/problem.R
@@ -355,7 +355,7 @@ setClassUnion("SolutionORList", c("Solution", "list"))
                     ## environment at argument level poses problems in
                     ## R 3.6 at least
                     validity = function(object) {
-                      if(!(class(object@objective) %in% c("Minimize", "Maximize")))
+                      if(!inherits(object@objective, c("Minimize", "Maximize")))
                         stop("[Problem: objective] objective must be Minimize or Maximize")
                       if(!is.na(object@value))
                         stop("[Problem: value] value should not be set by user")
@@ -996,7 +996,7 @@ saveDualValues <- function(object, result_vec, constraints, constr_types) {
     active_constraints <- list()
     for(constr in object@constraints) {
         # Ignore constraints of the wrong type
-        if(class(constr) %in% constr_types)
+        if(inherits(constr, constr_types))
             active_constraints <- c(active_constraints, constr)
     }
     saveValuesById(active_constraints, constr_offsets, result_vec)

--- a/R/qp2quad_form.R
+++ b/R/qp2quad_form.R
@@ -16,8 +16,8 @@ Qp2SymbolicQp.accepts <- function(problem) {
   is_qpwa(expr(problem@objective)) &&
   length(intersect(c("PSD", "NSD"), convex_attributes(variables(problem)))) == 0 &&
   all(sapply(problem@constraints, function(c) {
-        ((class(c) == "NonPosConstraint" || class(c) == "IneqConstraint") && is_pwl(expr(c))) ||
-        ((class(c) == "ZeroConstraint" || class(c) == "EqConstraint") && are_args_affine(list(c)))
+        (inherits(c, c("NonPosConstraint", "IneqConstraint")) && is_pwl(expr(c))) ||
+        (inherits(c, c("ZeroConstraint", "EqConstraint")) && are_args_affine(list(c)))
   }))
 }
 
@@ -50,12 +50,12 @@ setMethod("perform", signature(object = "Qp2SymbolicQp", problem = "Problem"), f
 QpMatrixStuffing <- setClass("QpMatrixStuffing", contains = "MatrixStuffing")
 
 setMethod("accepts", signature(object = "QpMatrixStuffing", problem = "Problem"), function(object, problem) {
-    class(problem@objective) == "Minimize" &&
+    inherits(problem@objective, "Minimize") &&
         is_quadratic(problem@objective) &&
         is_dcp(problem) &&
         length(convex_attributes(variables(problem))) == 0 &&
         are_args_affine(problem@constraints) &&
-        all(sapply(problem@constraints, function(c) { class(c) %in% c("ZeroConstraint", "NonPosConstraint", "EqConstraint", "IneqConstraint") }))
+        all(sapply(problem@constraints, inherits, what = c("ZeroConstraint", "NonPosConstraint", "EqConstraint", "IneqConstraint") ))
 })
 
 setMethod("stuffed_objective", signature(object = "QpMatrixStuffing", problem = "Problem", extractor = "CoeffExtractor"), function(object, problem, extractor) {

--- a/R/qp_solvers.R
+++ b/R/qp_solvers.R
@@ -6,7 +6,7 @@
 #' @return Is the objective a stuffed QP?
 is_stuffed_qp_objective <- function(objective) {
   expr <- expr(objective)
-  return(class(expr) == "AddExpression" && length(expr@args) == 2 && class(expr@args[[1]]) == "QuadForm" && class(expr@args[[2]]) == "MulExpression" && is_affine(expr@args[[2]]))
+  return(inherits(expr, "AddExpression") && length(expr@args) == 2 && inherits(expr@args[[1]], "QuadForm") && inherits(expr@args[[2]], "MulExpression") && is_affine(expr@args[[2]]))
 }
 
 #'
@@ -18,9 +18,9 @@ setClass("QpSolver", contains = "ReductionSolver")
 #' @param problem A \linkS4class{Problem} object.
 #' @describeIn QpSolver Is this a QP problem?
 setMethod("accepts", signature(object = "QpSolver", problem = "Problem"), function(object, problem) {
-  return(class(problem@objective) == "Minimize" && is_stuffed_qp_objective(problem@objective) && are_args_affine(problem@constraints) &&
-           all(sapply(problem@constraints, function(c) { class(c) == "ZeroConstraint" || class(c) == "NonPosConstraint" })))
-})
+  return(inherits(problem@objective, "Minimize") && is_stuffed_qp_objective(problem@objective) && are_args_affine(problem@constraints) &&
+           all(sapply(problem@constraints, inherits, what = c("ZeroConstraint", "NonPosConstraint" ))))
+})  
 
 #' @describeIn QpSolver Constructs a QP problem data stored in a list
 setMethod("perform", signature(object = "QpSolver", problem = "Problem"), function(object, problem) {
@@ -43,8 +43,8 @@ setMethod("perform", signature(object = "QpSolver", problem = "Problem"), functi
     eq_cons <- list()
     ineq_cons <- list()
   } else {
-    eq_cons <- problem@constraints[sapply(problem@constraints, function(c) { class(c) == "ZeroConstraint" })]
-    ineq_cons <- problem@constraints[sapply(problem@constraints, function(c) { class(c) == "NonPosConstraint" })]
+    eq_cons <- problem@constraints[sapply(problem@constraints, inherits, what = "ZeroConstraint" )]
+    ineq_cons <- problem@constraints[sapply(problem@constraints, inherits, what = "NonPosConstraint" )]
   }
 
   # TODO: This dependence on ConicSolver is hacky; something should change here.

--- a/R/reduction_solvers.R
+++ b/R/reduction_solvers.R
@@ -317,7 +317,7 @@ setMethod("construct_intermediate_chain", signature(problem = "Problem", candida
   }
 
   # Dcp2Cone and Qp2SymbolicQp require problems to minimize their objectives.
-  if(class(problem@objective) == "Maximize")
+  if(inherits(problem@objective, "Maximize"))
     reductions <- c(reductions, FlipObjective())
 
   # First, attempt to canonicalize the problem to a linearly constrained QP.

--- a/R/reduction_solvers.R
+++ b/R/reduction_solvers.R
@@ -195,11 +195,11 @@ construct_solving_chain <- function(problem, candidates) {
   # The types of atoms to check for are SOC atoms, PSD atoms, and exponential atoms.
   atoms <- atoms(problem)
   cones <- c()
-  if(any(atoms %in% SOC_ATOMS) || any(sapply(problem@constraints, class) == "SOC"))
+  if(any(atoms %in% SOC_ATOMS) || any(sapply(problem@constraints, inherits, what = "SOC")))
     cones <- c(cones, "SOC")
-  if(any(atoms %in% EXP_ATOMS) || any(sapply(problem@constraints, class) == "ExpCone"))
+  if(any(atoms %in% EXP_ATOMS) || any(sapply(problem@constraints, inherits, what = "ExpCone")))
     cones <- c(cones, "ExpCone")
-  if(any(atoms %in% PSD_ATOMS) || any(sapply(problem@constraints, class) == "PSDConstraint")
+  if(any(atoms %in% PSD_ATOMS) || any(sapply(problem@constraints, inherits, what = "PSDConstraint"))
                                || any(sapply(variables(problem), function(v) { is_psd(v) || is_nsd(v) })))
     cones <- c(cones, "PSDConstraint")
 

--- a/R/reductions.R
+++ b/R/reductions.R
@@ -206,7 +206,7 @@ setMethod("canonicalize_tree", "Canonicalization", function(object, expr) {
 setMethod("canonicalize_expr", "Canonicalization", function(object, expr, args) {
   if(is(expr, "Expression") && is_constant(expr)) {
     return(list(expr, list()))
-  } else if(class(expr) %in% names(object@canon_methods))
+  } else if(inherits(expr, names(object@canon_methods)))
     return(object@canon_methods[[class(expr)]](expr, args))   # TODO: Not working for DgpCanonMethods.
   else
     return(list(copy(expr, args), list()))

--- a/R/reductions.R
+++ b/R/reductions.R
@@ -173,7 +173,7 @@ setMethod("invert", signature(object = "Canonicalization", solution = "Solution"
 #' @describeIn Canonicalization Recursively canonicalize an Expression.
 setMethod("canonicalize_tree", "Canonicalization", function(object, expr) {
   # TODO: Don't copy affine expressions?
-  if(class(expr) == "PartialProblem") {
+  if(inherits(expr, "PartialProblem")) {
     canon <- canonicalize_tree(object, expr(expr@args[[1]]@objective))
     canon_expr <- canon[[1]]
     constrs <- canon[[2]]
@@ -450,7 +450,7 @@ setMethod("perform", signature(object = "EvalParams", problem = "Problem"), func
   # Do not instantiate a new objective if it does not contain parameters.
   if(length(parameters(problem@objective)) > 0) {
     obj_expr <- EvalParams.replace_params_with_consts(expr(problem@objective))
-    if(class(problem@objective) == "Maximize")
+    if(inherits(problem@objective, "Maximize"))
       objective <- Maximize(obj_expr)
     else
       objective <- Minimize(obj_expr)
@@ -499,7 +499,7 @@ setMethod("accepts", signature(object = "FlipObjective", problem = "Problem"), f
 #' @param problem A \linkS4class{Problem} object.
 #' @describeIn FlipObjective Flip a minimization objective to a maximization and vice versa.
 setMethod("perform", signature(object = "FlipObjective", problem = "Problem"), function(object, problem) {
-  if(class(problem@objective) == "Maximize")
+  if(inherits(problem@objective, "Maximize"))
     objective <- Minimize
   else
     objective <- Maximize
@@ -576,7 +576,7 @@ setMethod("perform", signature(object = "MatrixStuffing", problem = "Problem"), 
   }
 
   # Map of old constraint id to new constraint id.
-  inverse_data@minimize <- class(problem@objective) == "Minimize"
+  inverse_data@minimize <- inherits(problem@objective, "Minimize")
   new_prob <- Problem(Minimize(new_obj), new_cons)
   return(list(object, new_prob, inverse_data))
 })

--- a/R/transforms.R
+++ b/R/transforms.R
@@ -122,16 +122,16 @@ linearize <- function(expr) {
 #
 # setMethod("get_data", "PartialProblem", function(object) { c(object@opt_vars, object@dont_opt_vars) })
 # setMethod("is_convex", "PartialProblem", function(object) {
-#   is_dcp(object@args[[1]]) && class(object@args[[1]]@objective) == "Minimize"
+#   is_dcp(object@args[[1]]) && inherits(object@args[[1]]@objective, "Minimize")
 # })
 # setMethod("is_concave", "PartialProblem", function(object) {
-#   is_dcp(object@args[[1]]) && class(object@args[[1]]@objective) == "Maximize"
+#   is_dcp(object@args[[1]]) && inherits(object@args[[1]]@objective), "Maximize")
 # })
 # setMethod("is_log_log_convex", "PartialProblem", function(object) {
-#   is_dgp(object@args[[1]]) && class(object@args[[1]]@objective) == "Minimize"
+#   is_dgp(object@args[[1]]) && inherits(object@args[[1]]@objective, "Minimize")
 # })
 # setMethod("is_log_log_concave", "PartialProblem", function(object) {
-#   is_dgp(object@args[[1]]) && class(object@args[[1]]@objective) == "Maximize"
+#   is_dgp(object@args[[1]]) && inherits(object@args[[1]]@objective, "Maximize")
 # })
 # setMethod("is_nonneg", "PartialProblem", function(object) { is_nonneg(object@args[[1]]@objective@args[[1]]) })
 # setMethod("is_nonpos", "PartialProblem", function(object) { is_nonpos(object@args[[1]]@objective@args[[1]]) })
@@ -250,7 +250,7 @@ linearize <- function(expr) {
 #     obj <- objectives[[i]]
 #     sign <- ifelse(is_nonneg(Constant(priorities[[i]])), 1, -1)
 #     off_target <- sign * off_target
-#     if(class(obj) == "Minimize") {
+#     if(inherits(obj, "Minimize")) {
 #       expr <- (priorities[[i]] - off_target)*Pos(obj@args[[1]] - targets[[i]])
 #       expr <- expr + off_target*obj@args[[1]]
 #       if(length(limits) > 0)

--- a/man/Abs-class.Rd
+++ b/man/Abs-class.Rd
@@ -47,23 +47,23 @@ This class represents the elementwise absolute value.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The elementwise absolute value of the input.
+\item \code{to_numeric(Abs)}: The elementwise absolute value of the input.
 
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(Abs)}: Does the atom handle complex numbers?
 
-\item \code{sign_from_args}: The atom is positive.
+\item \code{sign_from_args(Abs)}: The atom is positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(Abs)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(Abs)}: The atom is not concave.
 
-\item \code{is_incr}: A logical value indicating whether the atom is weakly increasing.
+\item \code{is_incr(Abs)}: A logical value indicating whether the atom is weakly increasing.
 
-\item \code{is_decr}: A logical value indicating whether the atom is weakly decreasing.
+\item \code{is_decr(Abs)}: A logical value indicating whether the atom is weakly decreasing.
 
-\item \code{is_pwl}: Is \code{x} piecewise linear?
+\item \code{is_pwl(Abs)}: Is \code{x} piecewise linear?
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/AddExpression-class.Rd
+++ b/man/AddExpression-class.Rd
@@ -68,25 +68,25 @@ This class represents the sum of any number of expressions.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{dim_from_args}: The dimensions of the expression.
+\item \code{dim_from_args(AddExpression)}: The dimensions of the expression.
 
-\item \code{name}: The string form of the expression.
+\item \code{name(AddExpression)}: The string form of the expression.
 
-\item \code{to_numeric}: Sum all the values.
+\item \code{to_numeric(AddExpression)}: Sum all the values.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(AddExpression)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log convex?
+\item \code{is_atom_log_log_concave(AddExpression)}: Is the atom log-log convex?
 
-\item \code{is_symmetric}: Is the atom symmetric?
+\item \code{is_symmetric(AddExpression)}: Is the atom symmetric?
 
-\item \code{is_hermitian}: Is the atom hermitian?
+\item \code{is_hermitian(AddExpression)}: Is the atom hermitian?
 
-\item \code{copy}: Returns a shallow copy of the AddExpression atom
+\item \code{copy(AddExpression)}: Returns a shallow copy of the AddExpression atom
 
-\item \code{graph_implementation}: The graph implementation of the expression.
+\item \code{graph_implementation(AddExpression)}: The graph implementation of the expression.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/AffAtom-class.Rd
+++ b/man/AffAtom-class.Rd
@@ -60,32 +60,32 @@ This virtual class represents an affine atomic expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(AffAtom)}: Does the atom handle complex numbers?
 
-\item \code{sign_from_args}: The sign of the atom.
+\item \code{sign_from_args(AffAtom)}: The sign of the atom.
 
-\item \code{is_imag}: Is the atom imaginary?
+\item \code{is_imag(AffAtom)}: Is the atom imaginary?
 
-\item \code{is_complex}: Is the atom complex valued?
+\item \code{is_complex(AffAtom)}: Is the atom complex valued?
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(AffAtom)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is concave.
+\item \code{is_atom_concave(AffAtom)}: The atom is concave.
 
-\item \code{is_incr}: The atom is weakly increasing in every argument.
+\item \code{is_incr(AffAtom)}: The atom is weakly increasing in every argument.
 
-\item \code{is_decr}: The atom is not weakly decreasing in any argument.
+\item \code{is_decr(AffAtom)}: The atom is not weakly decreasing in any argument.
 
-\item \code{is_quadratic}: Is every argument quadratic?
+\item \code{is_quadratic(AffAtom)}: Is every argument quadratic?
 
-\item \code{is_qpwa}: Is every argument quadratic of piecewise affine?
+\item \code{is_qpwa(AffAtom)}: Is every argument quadratic of piecewise affine?
 
-\item \code{is_pwl}: Is every argument piecewise linear?
+\item \code{is_pwl(AffAtom)}: Is every argument piecewise linear?
 
-\item \code{is_psd}: Is the atom a positive semidefinite matrix?
+\item \code{is_psd(AffAtom)}: Is the atom a positive semidefinite matrix?
 
-\item \code{is_nsd}: Is the atom a negative semidefinite matrix?
+\item \code{is_nsd(AffAtom)}: Is the atom a negative semidefinite matrix?
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(AffAtom)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-

--- a/man/Atom-class.Rd
+++ b/man/Atom-class.Rd
@@ -83,46 +83,46 @@ This virtual class represents atomic expressions in CVXR.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: Returns the string representtation of the function call
+\item \code{name(Atom)}: Returns the string representtation of the function call
 
-\item \code{validate_args}: Raises an error if the arguments are invalid.
+\item \code{validate_args(Atom)}: Raises an error if the arguments are invalid.
 
-\item \code{dim}: The \code{c(row, col)} dimensions of the atom.
+\item \code{dim(Atom)}: The \code{c(row, col)} dimensions of the atom.
 
-\item \code{nrow}: The number of rows in the atom.
+\item \code{nrow(Atom)}: The number of rows in the atom.
 
-\item \code{ncol}: The number of columns in the atom.
+\item \code{ncol(Atom)}: The number of columns in the atom.
 
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(Atom)}: Does the atom handle complex numbers?
 
-\item \code{is_nonneg}: A logical value indicating whether the atom is nonnegative.
+\item \code{is_nonneg(Atom)}: A logical value indicating whether the atom is nonnegative.
 
-\item \code{is_nonpos}: A logical value indicating whether the atom is nonpositive.
+\item \code{is_nonpos(Atom)}: A logical value indicating whether the atom is nonpositive.
 
-\item \code{is_imag}: A logical value indicating whether the atom is imaginary.
+\item \code{is_imag(Atom)}: A logical value indicating whether the atom is imaginary.
 
-\item \code{is_complex}: A logical value indicating whether the atom is complex valued.
+\item \code{is_complex(Atom)}: A logical value indicating whether the atom is complex valued.
 
-\item \code{is_convex}: A logical value indicating whether the atom is convex.
+\item \code{is_convex(Atom)}: A logical value indicating whether the atom is convex.
 
-\item \code{is_concave}: A logical value indicating whether the atom is concave.
+\item \code{is_concave(Atom)}: A logical value indicating whether the atom is concave.
 
-\item \code{is_log_log_convex}: A logical value indicating whether the atom is log-log convex.
+\item \code{is_log_log_convex(Atom)}: A logical value indicating whether the atom is log-log convex.
 
-\item \code{is_log_log_concave}: A logical value indicating whether the atom is log-log concave.
+\item \code{is_log_log_concave(Atom)}: A logical value indicating whether the atom is log-log concave.
 
-\item \code{canonicalize}: Represent the atom as an affine objective and conic constraints.
+\item \code{canonicalize(Atom)}: Represent the atom as an affine objective and conic constraints.
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(Atom)}: The graph implementation of the atom.
 
-\item \code{value_impl}: Returns the value of each of the componets in an Atom. Returns an empty matrix if it's an empty atom
+\item \code{value_impl(Atom)}: Returns the value of each of the componets in an Atom. Returns an empty matrix if it's an empty atom
 
-\item \code{value}: Returns the value of the atom.
+\item \code{value(Atom)}: Returns the value of the atom.
 
-\item \code{grad}: The (sub/super)-gradient of the atom with respect to each variable.
+\item \code{grad(Atom)}: The (sub/super)-gradient of the atom with respect to each variable.
 
-\item \code{domain}: A list of constraints describing the closure of the region where the expression is finite.
+\item \code{domain(Atom)}: A list of constraints describing the closure of the region where the expression is finite.
 
-\item \code{atoms}: Returns a list of the atom types present amongst this atom's arguments
+\item \code{atoms(Atom)}: Returns a list of the atom types present amongst this atom's arguments
+
 }}
-

--- a/man/AxisAtom-class.Rd
+++ b/man/AxisAtom-class.Rd
@@ -33,17 +33,17 @@ This virtual class represents atomic expressions that can be applied along an ax
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{dim_from_args}: The dimensions of the atom determined from its arguments.
+\item \code{dim_from_args(AxisAtom)}: The dimensions of the atom determined from its arguments.
 
-\item \code{get_data}: A list containing \code{axis} and \code{keepdims}.
+\item \code{get_data(AxisAtom)}: A list containing \code{axis} and \code{keepdims}.
 
-\item \code{validate_args}: Check that the new dimensions have the same number of entries as the old.
+\item \code{validate_args(AxisAtom)}: Check that the new dimensions have the same number of entries as the old.
 
-\item \code{.axis_grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.axis_grad(AxisAtom)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.column_grad}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+\item \code{.column_grad(AxisAtom)}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/BinaryOperator-class.Rd
+++ b/man/BinaryOperator-class.Rd
@@ -31,17 +31,17 @@ This base class represents expressions involving binary operators.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: Returns the name of the BinaryOperator object.
+\item \code{name(BinaryOperator)}: Returns the name of the BinaryOperator object.
 
-\item \code{to_numeric}: Apply the binary operator to the values.
+\item \code{to_numeric(BinaryOperator)}: Apply the binary operator to the values.
 
-\item \code{sign_from_args}: Default to rule for multiplication.
+\item \code{sign_from_args(BinaryOperator)}: Default to rule for multiplication.
 
-\item \code{is_imag}: Is the expression imaginary?
+\item \code{is_imag(BinaryOperator)}: Is the expression imaginary?
 
-\item \code{is_complex}: Is the expression complex valued?
+\item \code{is_complex(BinaryOperator)}: Is the expression complex valued?
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/CBC_CONIC-class.Rd
+++ b/man/CBC_CONIC-class.Rd
@@ -83,24 +83,24 @@ An interface to the CBC solver
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(CBC_CONIC)}: Can the solver handle mixed-integer programs?
 
-\item \code{status_map}: Converts status returned by the CBC solver to its respective CVXPY status.
+\item \code{status_map(CBC_CONIC)}: Converts status returned by the CBC solver to its respective CVXPY status.
 
-\item \code{status_map_mip}: Converts status returned by the CBC solver to its respective CVXPY status for mixed integer problems.
+\item \code{status_map_mip(CBC_CONIC)}: Converts status returned by the CBC solver to its respective CVXPY status for mixed integer problems.
 
-\item \code{status_map_lp}: Converts status returned by the CBC solver to its respective CVXPY status for linear problems.
+\item \code{status_map_lp(CBC_CONIC)}: Converts status returned by the CBC solver to its respective CVXPY status for linear problems.
 
-\item \code{name}: Returns the name of the solver
+\item \code{name(CBC_CONIC)}: Returns the name of the solver
 
-\item \code{import_solver}: Imports the solver
+\item \code{import_solver(CBC_CONIC)}: Imports the solver
 
-\item \code{accepts}: Can CBC_CONIC solve the problem?
+\item \code{accepts(object = CBC_CONIC, problem = Problem)}: Can CBC_CONIC solve the problem?
 
-\item \code{perform}: Returns a new problem and data for inverting the new solution.
+\item \code{perform(object = CBC_CONIC, problem = Problem)}: Returns a new problem and data for inverting the new solution.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = CBC_CONIC, solution = list, inverse_data = list)}: Returns the solution to the original problem given the inverse_data.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(CBC_CONIC)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/CPLEX_CONIC-class.Rd
+++ b/man/CPLEX_CONIC-class.Rd
@@ -78,20 +78,20 @@ An interface for the CPLEX solver
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(CPLEX_CONIC)}: Can the solver handle mixed-integer programs?
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(CPLEX_CONIC)}: Returns the name of the solver.
 
-\item \code{import_solver}: Imports the solver.
+\item \code{import_solver(CPLEX_CONIC)}: Imports the solver.
 
-\item \code{accepts}: Can CPLEX solve the problem?
+\item \code{accepts(object = CPLEX_CONIC, problem = Problem)}: Can CPLEX solve the problem?
 
-\item \code{status_map}: Converts status returned by the CPLEX solver to its respective CVXPY status.
+\item \code{status_map(CPLEX_CONIC)}: Converts status returned by the CPLEX solver to its respective CVXPY status.
 
-\item \code{perform}: Returns a new problem and data for inverting the new solution.
+\item \code{perform(object = CPLEX_CONIC, problem = Problem)}: Returns a new problem and data for inverting the new solution.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = CPLEX_CONIC, solution = list, inverse_data = list)}: Returns the solution to the original problem given the inverse_data.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(CPLEX_CONIC)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/CPLEX_QP-class.Rd
+++ b/man/CPLEX_QP-class.Rd
@@ -69,16 +69,16 @@ An interface for the CPLEX solver.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(CPLEX_QP)}: Can the solver handle mixed-integer programs?
 
-\item \code{status_map}: Converts status returned by the CPLEX solver to its respective CVXPY status.
+\item \code{status_map(CPLEX_QP)}: Converts status returned by the CPLEX solver to its respective CVXPY status.
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(CPLEX_QP)}: Returns the name of the solver.
 
-\item \code{import_solver}: Imports the solver.
+\item \code{import_solver(CPLEX_QP)}: Imports the solver.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = CPLEX_QP, solution = list, inverse_data = InverseData)}: Returns the solution to the original problem given the inverse_data.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(CPLEX_QP)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/CVXOPT-class.Rd
+++ b/man/CVXOPT-class.Rd
@@ -74,20 +74,20 @@ An interface for the CVXOPT solver.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(CVXOPT)}: Can the solver handle mixed-integer programs?
 
-\item \code{status_map}: Converts status returned by the CVXOPT solver to its respective CVXPY status.
+\item \code{status_map(CVXOPT)}: Converts status returned by the CVXOPT solver to its respective CVXPY status.
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(CVXOPT)}: Returns the name of the solver.
 
-\item \code{import_solver}: Imports the solver.
+\item \code{import_solver(CVXOPT)}: Imports the solver.
 
-\item \code{accepts}: Can CVXOPT solve the problem?
+\item \code{accepts(object = CVXOPT, problem = Problem)}: Can CVXOPT solve the problem?
 
-\item \code{perform}: Returns a new problem and data for inverting the new solution.
+\item \code{perform(object = CVXOPT, problem = Problem)}: Returns a new problem and data for inverting the new solution.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = CVXOPT, solution = list, inverse_data = list)}: Returns the solution to the original problem given the inverse_data.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(CVXOPT)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/Canonical-class.Rd
+++ b/man/Canonical-class.Rd
@@ -37,20 +37,20 @@ This virtual class represents a canonical expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{expr}: The expression associated with the input.
+\item \code{expr(Canonical)}: The expression associated with the input.
 
-\item \code{id}: The unique ID of the canonical expression.
+\item \code{id(Canonical)}: The unique ID of the canonical expression.
 
-\item \code{canonical_form}: The graph implementation of the input.
+\item \code{canonical_form(Canonical)}: The graph implementation of the input.
 
-\item \code{variables}: List of \linkS4class{Variable} objects in the expression.
+\item \code{variables(Canonical)}: List of \linkS4class{Variable} objects in the expression.
 
-\item \code{parameters}: List of \linkS4class{Parameter} objects in the expression.
+\item \code{parameters(Canonical)}: List of \linkS4class{Parameter} objects in the expression.
 
-\item \code{constants}: List of \linkS4class{Constant} objects in the expression.
+\item \code{constants(Canonical)}: List of \linkS4class{Constant} objects in the expression.
 
-\item \code{atoms}: List of \linkS4class{Atom} objects in the expression.
+\item \code{atoms(Canonical)}: List of \linkS4class{Atom} objects in the expression.
 
-\item \code{get_data}: Information needed to reconstruct the expression aside from its arguments.
+\item \code{get_data(Canonical)}: Information needed to reconstruct the expression aside from its arguments.
+
 }}
-

--- a/man/Canonicalization-class.Rd
+++ b/man/Canonicalization-class.Rd
@@ -36,12 +36,16 @@ This class represents a canonicalization reduction.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{perform}: Recursively canonicalize the objective and every constraint.
+\item \code{perform(object = Canonicalization, problem = Problem)}: Recursively canonicalize the objective and every constraint.
 
-\item \code{invert}: Performs the reduction on a problem and returns an equivalent problem.
+\item \code{invert(
+  object = Canonicalization,
+  solution = Solution,
+  inverse_data = InverseData
+)}: Performs the reduction on a problem and returns an equivalent problem.
 
-\item \code{canonicalize_tree}: Recursively canonicalize an Expression.
+\item \code{canonicalize_tree(Canonicalization)}: Recursively canonicalize an Expression.
 
-\item \code{canonicalize_expr}: Canonicalize an expression, w.r.t. canonicalized arguments.
+\item \code{canonicalize_expr(Canonicalization)}: Canonicalize an expression, w.r.t. canonicalized arguments.
+
 }}
-

--- a/man/Chain-class.Rd
+++ b/man/Chain-class.Rd
@@ -33,11 +33,11 @@ their constraint values.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{accepts}: A problem is accepted if the sequence of reductions is valid. In particular, the i-th reduction must accept the output of the i-1th
+\item \code{accepts(object = Chain, problem = Problem)}: A problem is accepted if the sequence of reductions is valid. In particular, the i-th reduction must accept the output of the i-1th
 reduction, with the first reduction (self.reductions[0]) in the sequence taking as input the supplied problem.
 
-\item \code{perform}: Applies the chain to a problem and returns an equivalent problem.
+\item \code{perform(object = Chain, problem = Problem)}: Applies the chain to a problem and returns an equivalent problem.
 
-\item \code{invert}: Performs the reduction on a problem and returns an equivalent problem.
+\item \code{invert(object = Chain, solution = SolutionORList, inverse_data = list)}: Performs the reduction on a problem and returns an equivalent problem.
+
 }}
-

--- a/man/Complex2Real-class.Rd
+++ b/man/Complex2Real-class.Rd
@@ -30,10 +30,10 @@ an equivalent real problem.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{accepts}: Checks whether or not the problem involves any complex numbers.
+\item \code{accepts(object = Complex2Real, problem = Problem)}: Checks whether or not the problem involves any complex numbers.
 
-\item \code{perform}: Converts a Complex problem into a Real one.
+\item \code{perform(object = Complex2Real, problem = Problem)}: Converts a Complex problem into a Real one.
 
-\item \code{invert}: Returns a solution to the original problem given the inverse data.
+\item \code{invert(object = Complex2Real, solution = Solution, inverse_data = InverseData)}: Returns a solution to the original problem given the inverse data.
+
 }}
-

--- a/man/ConeMatrixStuffing-class.Rd
+++ b/man/ConeMatrixStuffing-class.Rd
@@ -31,8 +31,12 @@ subject to cone_constr1(A_1*x + b_1, ...)
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{accepts}: Is the solver accepted?
+\item \code{accepts(object = ConeMatrixStuffing, problem = Problem)}: Is the solver accepted?
 
-\item \code{stuffed_objective}: Returns a list of the stuffed matrices
+\item \code{stuffed_objective(
+  object = ConeMatrixStuffing,
+  problem = Problem,
+  extractor = CoeffExtractor
+)}: Returns a list of the stuffed matrices
+
 }}
-

--- a/man/ConicSolver-class.Rd
+++ b/man/ConicSolver-class.Rd
@@ -38,9 +38,9 @@ Conic solver class with reduction semantics.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{accepts}: Can the problem be solved with a conic solver?
+\item \code{accepts(object = ConicSolver, problem = Problem)}: Can the problem be solved with a conic solver?
 
-\item \code{reduction_format_constr}: Return a list representing a cone program whose problem data tensors
+\item \code{reduction_format_constr(ConicSolver)}: Return a list representing a cone program whose problem data tensors
 will yield the coefficient "A" and offset "b" for the respective constraints:
 Linear Equations: A %*% x == b,
 Linear inequalities: A %*% x <= b,
@@ -48,8 +48,8 @@ Second order cone: A %*% x <=_{SOC} b,
 Exponential cone: A %*% x <=_{EXP} b,
 Semidefinite cone: A %*% x <=_{SOP} b.
 
-\item \code{group_coeff_offset}: Combine the constraints into a single matrix, offset.
+\item \code{group_coeff_offset(ConicSolver)}: Combine the constraints into a single matrix, offset.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = ConicSolver, solution = Solution, inverse_data = InverseData)}: Returns the solution to the original problem given the inverse_data.
+
 }}
-

--- a/man/Conjugate-class.Rd
+++ b/man/Conjugate-class.Rd
@@ -41,19 +41,19 @@ This class represents the complex conjugate of an expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Elementwise complex conjugate of the constant.
+\item \code{to_numeric(Conjugate)}: Elementwise complex conjugate of the constant.
 
-\item \code{dim_from_args}: The (row, col) dimensions of the expression.
+\item \code{dim_from_args(Conjugate)}: The (row, col) dimensions of the expression.
 
-\item \code{is_incr}: Is the composition weakly increasing in argument idx?
+\item \code{is_incr(Conjugate)}: Is the composition weakly increasing in argument idx?
 
-\item \code{is_decr}: Is the composition weakly decreasing in argument idx?
+\item \code{is_decr(Conjugate)}: Is the composition weakly decreasing in argument idx?
 
-\item \code{is_symmetric}: Is the expression symmetric?
+\item \code{is_symmetric(Conjugate)}: Is the expression symmetric?
 
-\item \code{is_hermitian}: Is the expression hermitian?
+\item \code{is_hermitian(Conjugate)}: Is the expression hermitian?
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Constant-class.Rd
+++ b/man/Constant-class.Rd
@@ -77,37 +77,37 @@ Coerce an R object or expression into the \linkS4class{Constant} class.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The name of the constant.
+\item \code{name(Constant)}: The name of the constant.
 
-\item \code{constants}: Returns itself as a constant.
+\item \code{constants(Constant)}: Returns itself as a constant.
 
-\item \code{value}: The value of the constant.
+\item \code{value(Constant)}: The value of the constant.
 
-\item \code{is_pos}: A logical value indicating whether all elements of the constant are positive.
+\item \code{is_pos(Constant)}: A logical value indicating whether all elements of the constant are positive.
 
-\item \code{grad}: An empty list since the gradient of a constant is zero.
+\item \code{grad(Constant)}: An empty list since the gradient of a constant is zero.
 
-\item \code{dim}: The \code{c(row, col)} dimensions of the constant.
+\item \code{dim(Constant)}: The \code{c(row, col)} dimensions of the constant.
 
-\item \code{canonicalize}: The canonical form of the constant.
+\item \code{canonicalize(Constant)}: The canonical form of the constant.
 
-\item \code{is_nonneg}: A logical value indicating whether all elements of the constant are non-negative.
+\item \code{is_nonneg(Constant)}: A logical value indicating whether all elements of the constant are non-negative.
 
-\item \code{is_nonpos}: A logical value indicating whether all elements of the constant are non-positive.
+\item \code{is_nonpos(Constant)}: A logical value indicating whether all elements of the constant are non-positive.
 
-\item \code{is_imag}: A logical value indicating whether the constant is imaginary.
+\item \code{is_imag(Constant)}: A logical value indicating whether the constant is imaginary.
 
-\item \code{is_complex}: A logical value indicating whether the constant is complex-valued.
+\item \code{is_complex(Constant)}: A logical value indicating whether the constant is complex-valued.
 
-\item \code{is_symmetric}: A logical value indicating whether the constant is symmetric.
+\item \code{is_symmetric(Constant)}: A logical value indicating whether the constant is symmetric.
 
-\item \code{is_hermitian}: A logical value indicating whether the constant is a Hermitian matrix.
+\item \code{is_hermitian(Constant)}: A logical value indicating whether the constant is a Hermitian matrix.
 
-\item \code{is_psd}: A logical value indicating whether the constant is a positive semidefinite matrix.
+\item \code{is_psd(Constant)}: A logical value indicating whether the constant is a positive semidefinite matrix.
 
-\item \code{is_nsd}: A logical value indicating whether the constant is a negative semidefinite matrix.
+\item \code{is_nsd(Constant)}: A logical value indicating whether the constant is a negative semidefinite matrix.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/ConstantSolver-class.Rd
+++ b/man/ConstantSolver-class.Rd
@@ -76,22 +76,22 @@ The ConstantSolver class.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(ConstantSolver)}: Can the solver handle mixed-integer programs?
 
-\item \code{accepts}: Is the solver capable of solving the problem?
+\item \code{accepts(object = ConstantSolver, problem = Problem)}: Is the solver capable of solving the problem?
 
-\item \code{perform}: Returns a list of the ConstantSolver, Problem, and an empty list.
+\item \code{perform(object = ConstantSolver, problem = Problem)}: Returns a list of the ConstantSolver, Problem, and an empty list.
 
-\item \code{invert}: Returns the solution.
+\item \code{invert(object = ConstantSolver, solution = Solution, inverse_data = list)}: Returns the solution.
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(ConstantSolver)}: Returns the name of the solver.
 
-\item \code{import_solver}: Imports the solver.
+\item \code{import_solver(ConstantSolver)}: Imports the solver.
 
-\item \code{is_installed}: Is the solver installed?
+\item \code{is_installed(ConstantSolver)}: Is the solver installed?
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(ConstantSolver)}: Solve a problem represented by data returned from apply.
 
-\item \code{reduction_solve}: Solve the problem and return a \linkS4class{Solution} object.
+\item \code{reduction_solve(object = ConstantSolver, problem = ANY)}: Solve the problem and return a \linkS4class{Solution} object.
+
 }}
-

--- a/man/Constraint-class.Rd
+++ b/man/Constraint-class.Rd
@@ -63,32 +63,32 @@ This virtual class represents a mathematical constraint.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{dim}: The dimensions of the constrained expression.
+\item \code{dim(Constraint)}: The dimensions of the constrained expression.
 
-\item \code{size}: The size of the constrained expression.
+\item \code{size(Constraint)}: The size of the constrained expression.
 
-\item \code{is_real}: Is the constraint real?
+\item \code{is_real(Constraint)}: Is the constraint real?
 
-\item \code{is_imag}: Is the constraint imaginary?
+\item \code{is_imag(Constraint)}: Is the constraint imaginary?
 
-\item \code{is_complex}: Is the constraint complex?
+\item \code{is_complex(Constraint)}: Is the constraint complex?
 
-\item \code{is_dcp}: Is the constraint DCP?
+\item \code{is_dcp(Constraint)}: Is the constraint DCP?
 
-\item \code{is_dgp}: Is the constraint DGP?
+\item \code{is_dgp(Constraint)}: Is the constraint DGP?
 
-\item \code{residual}: The residual of a constraint
+\item \code{residual(Constraint)}: The residual of a constraint
 
-\item \code{violation}: The violation of a constraint.
+\item \code{violation(Constraint)}: The violation of a constraint.
 
-\item \code{constr_value}: The value of a constraint.
+\item \code{constr_value(Constraint)}: The value of a constraint.
 
-\item \code{get_data}: Information needed to reconstruct the object aside from the args.
+\item \code{get_data(Constraint)}: Information needed to reconstruct the object aside from the args.
 
-\item \code{dual_value}: The dual values of a constraint.
+\item \code{dual_value(Constraint)}: The dual values of a constraint.
 
-\item \code{dual_value<-}: Replaces the dual values of a constraint..
+\item \code{dual_value(Constraint) <- value}: Replaces the dual values of a constraint..
 
-\item \code{size}: The size of the constrained expression.
+\item \code{size(ZeroConstraint)}: The size of the constrained expression.
+
 }}
-

--- a/man/Conv-class.Rd
+++ b/man/Conv-class.Rd
@@ -52,21 +52,21 @@ This class represents the 1-D discrete convolution of two vectors.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The convolution of the two values.
+\item \code{to_numeric(Conv)}: The convolution of the two values.
 
-\item \code{validate_args}: Check both arguments are vectors and the first is a constant.
+\item \code{validate_args(Conv)}: Check both arguments are vectors and the first is a constant.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(Conv)}: The dimensions of the atom.
 
-\item \code{sign_from_args}: The sign of the atom.
+\item \code{sign_from_args(Conv)}: The sign of the atom.
 
-\item \code{is_incr}: Is the left-hand expression positive?
+\item \code{is_incr(Conv)}: Is the left-hand expression positive?
 
-\item \code{is_decr}: Is the left-hand expression negative?
+\item \code{is_decr(Conv)}: Is the left-hand expression negative?
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(Conv)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/CumMax-class.Rd
+++ b/man/CumMax-class.Rd
@@ -57,27 +57,27 @@ This class represents the cumulative maximum of an expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The cumulative maximum along the axis.
+\item \code{to_numeric(CumMax)}: The cumulative maximum along the axis.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(CumMax)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.column_grad}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+\item \code{.column_grad(CumMax)}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
 
-\item \code{dim_from_args}: The dimensions of the atom determined from its arguments.
+\item \code{dim_from_args(CumMax)}: The dimensions of the atom determined from its arguments.
 
-\item \code{sign_from_args}: The (is positive, is negative) sign of the atom.
+\item \code{sign_from_args(CumMax)}: The (is positive, is negative) sign of the atom.
 
-\item \code{get_data}: Returns the axis along which the cumulative max is taken.
+\item \code{get_data(CumMax)}: Returns the axis along which the cumulative max is taken.
 
-\item \code{is_atom_convex}: Is the atom convex?
+\item \code{is_atom_convex(CumMax)}: Is the atom convex?
 
-\item \code{is_atom_concave}: Is the atom concave?
+\item \code{is_atom_concave(CumMax)}: Is the atom concave?
 
-\item \code{is_incr}: Is the atom weakly increasing in the index?
+\item \code{is_incr(CumMax)}: Is the atom weakly increasing in the index?
 
-\item \code{is_decr}: Is the atom weakly decreasing in the index?
+\item \code{is_decr(CumMax)}: Is the atom weakly decreasing in the index?
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/CumSum-class.Rd
+++ b/man/CumSum-class.Rd
@@ -44,17 +44,17 @@ This class represents the cumulative sum.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The cumulative sum of the values along the specified axis.
+\item \code{to_numeric(CumSum)}: The cumulative sum of the values along the specified axis.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(CumSum)}: The dimensions of the atom.
 
-\item \code{get_data}: Returns the axis along which the cumulative sum is taken.
+\item \code{get_data(CumSum)}: Returns the axis along which the cumulative sum is taken.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(CumSum)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(CumSum)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/CvxAttr2Constr-class.Rd
+++ b/man/CvxAttr2Constr-class.Rd
@@ -26,8 +26,8 @@ This class represents a reduction that expands convex variable attributes into c
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{perform}: Expand convex variable attributes to constraints.
+\item \code{perform(object = CvxAttr2Constr, problem = Problem)}: Expand convex variable attributes to constraints.
 
-\item \code{invert}: Performs the reduction on a problem and returns an equivalent problem.
+\item \code{invert(object = CvxAttr2Constr, solution = Solution, inverse_data = list)}: Performs the reduction on a problem and returns an equivalent problem.
+
 }}
-

--- a/man/Dcp2Cone-class.Rd
+++ b/man/Dcp2Cone-class.Rd
@@ -23,8 +23,8 @@ with affine objectives and conic constraints whose arguments are affine.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{accepts}: A problem is accepted if it is a minimization and is DCP.
+\item \code{accepts(object = Dcp2Cone, problem = Problem)}: A problem is accepted if it is a minimization and is DCP.
 
-\item \code{perform}: Converts a DCP problem to a conic form.
+\item \code{perform(object = Dcp2Cone, problem = Problem)}: Converts a DCP problem to a conic form.
+
 }}
-

--- a/man/Dgp2Dcp-class.Rd
+++ b/man/Dgp2Dcp-class.Rd
@@ -38,12 +38,12 @@ this reduction can be used to convert geometric programs into convex form.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{accepts}: Is the problem DGP?
+\item \code{accepts(object = Dgp2Dcp, problem = Problem)}: Is the problem DGP?
 
-\item \code{perform}: Converts the DGP problem to a DCP problem.
+\item \code{perform(object = Dgp2Dcp, problem = Problem)}: Converts the DGP problem to a DCP problem.
 
-\item \code{canonicalize_expr}: Canonicalizes each atom within an Dgp2Dcp expression.
+\item \code{canonicalize_expr(Dgp2Dcp)}: Canonicalizes each atom within an Dgp2Dcp expression.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = Dgp2Dcp, solution = Solution, inverse_data = InverseData)}: Returns the solution to the original problem given the inverse_data.
+
 }}
-

--- a/man/DgpCanonMethods-class.Rd
+++ b/man/DgpCanonMethods-class.Rd
@@ -22,9 +22,9 @@ Canonicalization of DGPs is a stateful procedure, hence the need for a class.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{names}: Returns the name of all the canonicalization methods
+\item \code{names(DgpCanonMethods)}: Returns the name of all the canonicalization methods
 
 \item \code{$}: Returns either a canonicalized variable or 
 a corresponding Dgp2Dcp canonicalization method
-}}
 
+}}

--- a/man/DiagMat-class.Rd
+++ b/man/DiagMat-class.Rd
@@ -42,17 +42,17 @@ This class represents the extraction of the diagonal from a square matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Extract the diagonal from a square matrix constant.
+\item \code{to_numeric(DiagMat)}: Extract the diagonal from a square matrix constant.
 
-\item \code{dim_from_args}: The size of the atom.
+\item \code{dim_from_args(DiagMat)}: The size of the atom.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(DiagMat)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(DiagMat)}: Is the atom log-log concave?
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(DiagMat)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/DiagVec-class.Rd
+++ b/man/DiagVec-class.Rd
@@ -48,21 +48,21 @@ This class represents the conversion of a vector into a diagonal matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Convert the vector constant into a diagonal matrix.
+\item \code{to_numeric(DiagVec)}: Convert the vector constant into a diagonal matrix.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(DiagVec)}: The dimensions of the atom.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(DiagVec)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(DiagVec)}: Is the atom log-log concave?
 
-\item \code{is_symmetric}: Is the expression symmetric?
+\item \code{is_symmetric(DiagVec)}: Is the expression symmetric?
 
-\item \code{is_hermitian}: Is the expression hermitian?
+\item \code{is_hermitian(DiagVec)}: Is the expression hermitian?
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(DiagVec)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/DivExpression-class.Rd
+++ b/man/DivExpression-class.Rd
@@ -69,26 +69,26 @@ This class represents one expression divided by another expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Matrix division by a scalar.
+\item \code{to_numeric(DivExpression)}: Matrix division by a scalar.
 
-\item \code{is_quadratic}: Is the left-hand expression quadratic and the right-hand expression constant?
+\item \code{is_quadratic(DivExpression)}: Is the left-hand expression quadratic and the right-hand expression constant?
 
-\item \code{is_qpwa}: Is the expression quadratic of piecewise affine?
+\item \code{is_qpwa(DivExpression)}: Is the expression quadratic of piecewise affine?
 
-\item \code{dim_from_args}: The (row, col) dimensions of the left-hand expression.
+\item \code{dim_from_args(DivExpression)}: The (row, col) dimensions of the left-hand expression.
 
-\item \code{is_atom_convex}: Division is convex (affine) in its arguments only if the denominator is constant.
+\item \code{is_atom_convex(DivExpression)}: Division is convex (affine) in its arguments only if the denominator is constant.
 
-\item \code{is_atom_concave}: Division is concave (affine) in its arguments only if the denominator is constant.
+\item \code{is_atom_concave(DivExpression)}: Division is concave (affine) in its arguments only if the denominator is constant.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(DivExpression)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(DivExpression)}: Is the atom log-log concave?
 
-\item \code{is_incr}: Is the right-hand expression positive?
+\item \code{is_incr(DivExpression)}: Is the right-hand expression positive?
 
-\item \code{is_decr}: Is the right-hand expression negative?
+\item \code{is_decr(DivExpression)}: Is the right-hand expression negative?
 
-\item \code{graph_implementation}: The graph implementation of the expression.
+\item \code{graph_implementation(DivExpression)}: The graph implementation of the expression.
+
 }}
-

--- a/man/ECOS-class.Rd
+++ b/man/ECOS-class.Rd
@@ -42,16 +42,16 @@ An interface for the ECOS solver
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(ECOS)}: Can the solver handle mixed-integer programs?
 
-\item \code{status_map}: Converts status returned by the ECOS solver to its respective CVXPY status.
+\item \code{status_map(ECOS)}: Converts status returned by the ECOS solver to its respective CVXPY status.
 
-\item \code{import_solver}: Imports the solver
+\item \code{import_solver(ECOS)}: Imports the solver
 
-\item \code{name}: Returns the name of the solver
+\item \code{name(ECOS)}: Returns the name of the solver
 
-\item \code{perform}: Returns a new problem and data for inverting the new solution.
+\item \code{perform(object = ECOS, problem = Problem)}: Returns a new problem and data for inverting the new solution.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = ECOS, solution = list, inverse_data = list)}: Returns the solution to the original problem given the inverse_data.
+
 }}
-

--- a/man/ECOS_BB-class.Rd
+++ b/man/ECOS_BB-class.Rd
@@ -59,12 +59,12 @@ An interface for the ECOS BB solver.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(ECOS_BB)}: Can the solver handle mixed-integer programs?
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(ECOS_BB)}: Returns the name of the solver.
 
-\item \code{perform}: Returns a new problem and data for inverting the new solution.
+\item \code{perform(object = ECOS_BB, problem = Problem)}: Returns a new problem and data for inverting the new solution.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(ECOS_BB)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/Elementwise-class.Rd
+++ b/man/Elementwise-class.Rd
@@ -23,10 +23,10 @@ This virtual class represents an elementwise atom.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{dim_from_args}: Dimensions is the same as the sum of the arguments' dimensions.
+\item \code{dim_from_args(Elementwise)}: Dimensions is the same as the sum of the arguments' dimensions.
 
-\item \code{validate_args}: Verify that all the dimensions are the same or can be promoted.
+\item \code{validate_args(Elementwise)}: Verify that all the dimensions are the same or can be promoted.
 
-\item \code{is_symmetric}: Is the expression symmetric?
+\item \code{is_symmetric(Elementwise)}: Is the expression symmetric?
+
 }}
-

--- a/man/EliminatePwl-class.Rd
+++ b/man/EliminatePwl-class.Rd
@@ -19,6 +19,6 @@ This class eliminates piecewise linear atoms.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{accepts}: Does this problem contain piecewise linear atoms?
-}}
+\item \code{accepts(object = EliminatePwl, problem = Problem)}: Does this problem contain piecewise linear atoms?
 
+}}

--- a/man/Entr-class.Rd
+++ b/man/Entr-class.Rd
@@ -47,23 +47,23 @@ This class represents the elementwise operation \eqn{-xlog(x)}.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The elementwise entropy function evaluated at the value.
+\item \code{to_numeric(Entr)}: The elementwise entropy function evaluated at the value.
 
-\item \code{sign_from_args}: The sign of the atom is unknown.
+\item \code{sign_from_args(Entr)}: The sign of the atom is unknown.
 
-\item \code{is_atom_convex}: The atom is not convex.
+\item \code{is_atom_convex(Entr)}: The atom is not convex.
 
-\item \code{is_atom_concave}: The atom is concave.
+\item \code{is_atom_concave(Entr)}: The atom is concave.
 
-\item \code{is_incr}: The atom is weakly increasing.
+\item \code{is_incr(Entr)}: The atom is weakly increasing.
 
-\item \code{is_decr}: The atom is weakly decreasing.
+\item \code{is_decr(Entr)}: The atom is weakly decreasing.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(Entr)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.domain}: Returns constraints descrbing the domain of the node
+\item \code{.domain(Entr)}: Returns constraints descrbing the domain of the node
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/EqConstraint-class.Rd
+++ b/man/EqConstraint-class.Rd
@@ -46,18 +46,18 @@ The EqConstraint class
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The string representation of the constraint.
+\item \code{name(EqConstraint)}: The string representation of the constraint.
 
-\item \code{dim}: The dimensions of the constrained expression.
+\item \code{dim(EqConstraint)}: The dimensions of the constrained expression.
 
-\item \code{size}: The size of the constrained expression.
+\item \code{size(EqConstraint)}: The size of the constrained expression.
 
-\item \code{expr}: The expression to constrain.
+\item \code{expr(EqConstraint)}: The expression to constrain.
 
-\item \code{is_dcp}: Is the constraint DCP?
+\item \code{is_dcp(EqConstraint)}: Is the constraint DCP?
 
-\item \code{is_dgp}: Is the constraint DGP?
+\item \code{is_dgp(EqConstraint)}: Is the constraint DGP?
 
-\item \code{residual}: The residual of the constraint..
+\item \code{residual(EqConstraint)}: The residual of the constraint..
+
 }}
-

--- a/man/EvalParams-class.Rd
+++ b/man/EvalParams-class.Rd
@@ -27,8 +27,8 @@ their constaint values.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{perform}: Replace parameters with constant values.
+\item \code{perform(object = EvalParams, problem = Problem)}: Replace parameters with constant values.
 
-\item \code{invert}: Returns a solution to the original problem given the inverse_data.
+\item \code{invert(object = EvalParams, solution = Solution, inverse_data = list)}: Returns a solution to the original problem given the inverse_data.
+
 }}
-

--- a/man/Exp-class.Rd
+++ b/man/Exp-class.Rd
@@ -50,25 +50,25 @@ This class represents the elementwise natural exponential \eqn{e^x}.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The matrix with each element exponentiated.
+\item \code{to_numeric(Exp)}: The matrix with each element exponentiated.
 
-\item \code{sign_from_args}: The atom is positive.
+\item \code{sign_from_args(Exp)}: The atom is positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(Exp)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(Exp)}: The atom is not concave.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Exp)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Exp)}: Is the atom log-log concave?
 
-\item \code{is_incr}: The atom is weakly increasing.
+\item \code{is_incr(Exp)}: The atom is weakly increasing.
 
-\item \code{is_decr}: The atom is not weakly decreasing.
+\item \code{is_decr(Exp)}: The atom is not weakly decreasing.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(Exp)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/ExpCone-class.Rd
+++ b/man/ExpCone-class.Rd
@@ -59,21 +59,21 @@ K = \{(x,y,z) | y, z > 0, y\log(y) + x \leq y\log(z)\} \cup \{(x,y,z) | x \leq 0
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{residual}: The size of the \code{x} argument.
+\item \code{residual(ExpCone)}: The size of the \code{x} argument.
 
-\item \code{size}: The number of entries in the combined cones.
+\item \code{size(ExpCone)}: The number of entries in the combined cones.
 
-\item \code{num_cones}: The number of elementwise cones.
+\item \code{num_cones(ExpCone)}: The number of elementwise cones.
 
-\item \code{cone_sizes}: The dimensions of the exponential cones.
+\item \code{cone_sizes(ExpCone)}: The dimensions of the exponential cones.
 
-\item \code{is_dcp}: An exponential constraint is DCP if each argument is affine.
+\item \code{is_dcp(ExpCone)}: An exponential constraint is DCP if each argument is affine.
 
-\item \code{is_dgp}: Is the constraint DGP?
+\item \code{is_dgp(ExpCone)}: Is the constraint DGP?
 
-\item \code{canonicalize}: Canonicalizes by converting expressions to LinOps.
+\item \code{canonicalize(ExpCone)}: Canonicalizes by converting expressions to LinOps.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Expression-class.Rd
+++ b/man/Expression-class.Rd
@@ -128,80 +128,80 @@ This class represents a mathematical expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{value}: The value of the expression.
+\item \code{value(Expression)}: The value of the expression.
 
-\item \code{grad}: The (sub/super)-gradient of the expression with respect to each variable.
+\item \code{grad(Expression)}: The (sub/super)-gradient of the expression with respect to each variable.
 
-\item \code{domain}: A list of constraints describing the closure of the region where the expression is finite.
+\item \code{domain(Expression)}: A list of constraints describing the closure of the region where the expression is finite.
 
-\item \code{as.character}: The string representation of the expression.
+\item \code{as.character(Expression)}: The string representation of the expression.
 
-\item \code{name}: The name of the expression.
+\item \code{name(Expression)}: The name of the expression.
 
-\item \code{expr}: The expression itself.
+\item \code{expr(Expression)}: The expression itself.
 
-\item \code{is_constant}: The expression is constant if it contains no variables or is identically zero.
+\item \code{is_constant(Expression)}: The expression is constant if it contains no variables or is identically zero.
 
-\item \code{is_affine}: The expression is affine if it is constant or both convex and concave.
+\item \code{is_affine(Expression)}: The expression is affine if it is constant or both convex and concave.
 
-\item \code{is_convex}: A logical value indicating whether the expression is convex.
+\item \code{is_convex(Expression)}: A logical value indicating whether the expression is convex.
 
-\item \code{is_concave}: A logical value indicating whether the expression is concave.
+\item \code{is_concave(Expression)}: A logical value indicating whether the expression is concave.
 
-\item \code{is_dcp}: The expression is DCP if it is convex or concave.
+\item \code{is_dcp(Expression)}: The expression is DCP if it is convex or concave.
 
-\item \code{is_log_log_constant}: Is the expression log-log constant, i.e., elementwise positive?
+\item \code{is_log_log_constant(Expression)}: Is the expression log-log constant, i.e., elementwise positive?
 
-\item \code{is_log_log_affine}: Is the expression log-log affine?
+\item \code{is_log_log_affine(Expression)}: Is the expression log-log affine?
 
-\item \code{is_log_log_convex}: Is the expression log-log convex?
+\item \code{is_log_log_convex(Expression)}: Is the expression log-log convex?
 
-\item \code{is_log_log_concave}: Is the expression log-log concave?
+\item \code{is_log_log_concave(Expression)}: Is the expression log-log concave?
 
-\item \code{is_dgp}: The expression is DGP if it is log-log DCP.
+\item \code{is_dgp(Expression)}: The expression is DGP if it is log-log DCP.
 
-\item \code{is_hermitian}: A logical value indicating whether the expression is a Hermitian matrix.
+\item \code{is_hermitian(Expression)}: A logical value indicating whether the expression is a Hermitian matrix.
 
-\item \code{is_psd}: A logical value indicating whether the expression is a positive semidefinite matrix.
+\item \code{is_psd(Expression)}: A logical value indicating whether the expression is a positive semidefinite matrix.
 
-\item \code{is_nsd}: A logical value indicating whether the expression is a negative semidefinite matrix.
+\item \code{is_nsd(Expression)}: A logical value indicating whether the expression is a negative semidefinite matrix.
 
-\item \code{is_quadratic}: A logical value indicating whether the expression is quadratic.
+\item \code{is_quadratic(Expression)}: A logical value indicating whether the expression is quadratic.
 
-\item \code{is_symmetric}: A logical value indicating whether the expression is symmetric.
+\item \code{is_symmetric(Expression)}: A logical value indicating whether the expression is symmetric.
 
-\item \code{is_pwl}: A logical value indicating whether the expression is piecewise linear.
+\item \code{is_pwl(Expression)}: A logical value indicating whether the expression is piecewise linear.
 
-\item \code{is_qpwa}: A logical value indicating whether the expression is quadratic of piecewise affine.
+\item \code{is_qpwa(Expression)}: A logical value indicating whether the expression is quadratic of piecewise affine.
 
-\item \code{is_zero}: The expression is zero if it is both nonnegative and nonpositive.
+\item \code{is_zero(Expression)}: The expression is zero if it is both nonnegative and nonpositive.
 
-\item \code{is_nonneg}: A logical value indicating whether the expression is nonnegative.
+\item \code{is_nonneg(Expression)}: A logical value indicating whether the expression is nonnegative.
 
-\item \code{is_nonpos}: A logical value indicating whether the expression is nonpositive.
+\item \code{is_nonpos(Expression)}: A logical value indicating whether the expression is nonpositive.
 
-\item \code{dim}: The \code{c(row, col)} dimensions of the expression.
+\item \code{dim(Expression)}: The \code{c(row, col)} dimensions of the expression.
 
-\item \code{is_real}: A logical value indicating whether the expression is real.
+\item \code{is_real(Expression)}: A logical value indicating whether the expression is real.
 
-\item \code{is_imag}: A logical value indicating whether the expression is imaginary.
+\item \code{is_imag(Expression)}: A logical value indicating whether the expression is imaginary.
 
-\item \code{is_complex}: A logical value indicating whether the expression is complex.
+\item \code{is_complex(Expression)}: A logical value indicating whether the expression is complex.
 
-\item \code{size}: The number of entries in the expression.
+\item \code{size(Expression)}: The number of entries in the expression.
 
-\item \code{ndim}: The number of dimensions of the expression.
+\item \code{ndim(Expression)}: The number of dimensions of the expression.
 
-\item \code{flatten}: Vectorizes the expression.
+\item \code{flatten(Expression)}: Vectorizes the expression.
 
-\item \code{is_scalar}: A logical value indicating whether the expression is a scalar.
+\item \code{is_scalar(Expression)}: A logical value indicating whether the expression is a scalar.
 
-\item \code{is_vector}: A logical value indicating whether the expression is a row or column vector.
+\item \code{is_vector(Expression)}: A logical value indicating whether the expression is a row or column vector.
 
-\item \code{is_matrix}: A logical value indicating whether the expression is a matrix.
+\item \code{is_matrix(Expression)}: A logical value indicating whether the expression is a matrix.
 
-\item \code{nrow}: Number of rows in the expression.
+\item \code{nrow(Expression)}: Number of rows in the expression.
 
-\item \code{ncol}: Number of columns in the expression.
+\item \code{ncol(Expression)}: Number of columns in the expression.
+
 }}
-

--- a/man/EyeMinusInv-class.Rd
+++ b/man/EyeMinusInv-class.Rd
@@ -58,29 +58,29 @@ This atom is log-log convex.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The unity resolvent of the matrix.
+\item \code{to_numeric(EyeMinusInv)}: The unity resolvent of the matrix.
 
-\item \code{name}: The name and arguments of the atom.
+\item \code{name(EyeMinusInv)}: The name and arguments of the atom.
 
-\item \code{dim_from_args}: The dimensions of the atom determined from its arguments.
+\item \code{dim_from_args(EyeMinusInv)}: The dimensions of the atom determined from its arguments.
 
-\item \code{sign_from_args}: The (is positive, is negative) sign of the atom.
+\item \code{sign_from_args(EyeMinusInv)}: The (is positive, is negative) sign of the atom.
 
-\item \code{is_atom_convex}: Is the atom convex?
+\item \code{is_atom_convex(EyeMinusInv)}: Is the atom convex?
 
-\item \code{is_atom_concave}: Is the atom concave?
+\item \code{is_atom_concave(EyeMinusInv)}: Is the atom concave?
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(EyeMinusInv)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(EyeMinusInv)}: Is the atom log-log concave?
 
-\item \code{is_incr}: Is the atom weakly increasing in the index?
+\item \code{is_incr(EyeMinusInv)}: Is the atom weakly increasing in the index?
 
-\item \code{is_decr}: Is the atom weakly decreasing in the index?
+\item \code{is_decr(EyeMinusInv)}: Is the atom weakly decreasing in the index?
 
-\item \code{.grad}: Gives EyeMinusInv the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(EyeMinusInv)}: Gives EyeMinusInv the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/FlipObjective-class.Rd
+++ b/man/FlipObjective-class.Rd
@@ -27,8 +27,8 @@ maximization and vice versa.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{perform}: Flip a minimization objective to a maximization and vice versa.
+\item \code{perform(object = FlipObjective, problem = Problem)}: Flip a minimization objective to a maximization and vice versa.
 
-\item \code{invert}: Map the solution of the flipped problem to that of the original.
+\item \code{invert(object = FlipObjective, solution = Solution, inverse_data = list)}: Map the solution of the flipped problem to that of the original.
+
 }}
-

--- a/man/GLPK-class.Rd
+++ b/man/GLPK-class.Rd
@@ -69,16 +69,16 @@ An interface for the GLPK solver.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(GLPK)}: Can the solver handle mixed-integer programs?
 
-\item \code{status_map}: Converts status returned by the GLPK solver to its respective CVXPY status.
+\item \code{status_map(GLPK)}: Converts status returned by the GLPK solver to its respective CVXPY status.
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(GLPK)}: Returns the name of the solver.
 
-\item \code{import_solver}: Imports the solver.
+\item \code{import_solver(GLPK)}: Imports the solver.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = GLPK, solution = list, inverse_data = list)}: Returns the solution to the original problem given the inverse_data.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(GLPK)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/GLPK_MI-class.Rd
+++ b/man/GLPK_MI-class.Rd
@@ -59,12 +59,12 @@ An interface for the GLPK MI solver.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(GLPK_MI)}: Can the solver handle mixed-integer programs?
 
-\item \code{status_map}: Converts status returned by the GLPK_MI solver to its respective CVXPY status.
+\item \code{status_map(GLPK_MI)}: Converts status returned by the GLPK_MI solver to its respective CVXPY status.
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(GLPK_MI)}: Returns the name of the solver.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(GLPK_MI)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/GUROBI_CONIC-class.Rd
+++ b/man/GUROBI_CONIC-class.Rd
@@ -77,20 +77,20 @@ An interface for the GUROBI conic solver.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(GUROBI_CONIC)}: Can the solver handle mixed-integer programs?
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(GUROBI_CONIC)}: Returns the name of the solver.
 
-\item \code{import_solver}: Imports the solver.
+\item \code{import_solver(GUROBI_CONIC)}: Imports the solver.
 
-\item \code{status_map}: Converts status returned by the GUROBI solver to its respective CVXPY status.
+\item \code{status_map(GUROBI_CONIC)}: Converts status returned by the GUROBI solver to its respective CVXPY status.
 
-\item \code{accepts}: Can GUROBI_CONIC solve the problem?
+\item \code{accepts(object = GUROBI_CONIC, problem = Problem)}: Can GUROBI_CONIC solve the problem?
 
-\item \code{perform}: Returns a new problem and data for inverting the new solution.
+\item \code{perform(object = GUROBI_CONIC, problem = Problem)}: Returns a new problem and data for inverting the new solution.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = GUROBI_CONIC, solution = list, inverse_data = list)}: Returns the solution to the original problem given the inverse_data.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(GUROBI_CONIC)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/GUROBI_QP-class.Rd
+++ b/man/GUROBI_QP-class.Rd
@@ -69,16 +69,16 @@ An interface for the GUROBI_QP solver.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(GUROBI_QP)}: Can the solver handle mixed-integer programs?
 
-\item \code{status_map}: Converts status returned by the GUROBI solver to its respective CVXPY status.
+\item \code{status_map(GUROBI_QP)}: Converts status returned by the GUROBI solver to its respective CVXPY status.
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(GUROBI_QP)}: Returns the name of the solver.
 
-\item \code{import_solver}: Imports the solver.
+\item \code{import_solver(GUROBI_QP)}: Imports the solver.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(GUROBI_QP)}: Solve a problem represented by data returned from apply.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = GUROBI_QP, solution = list, inverse_data = InverseData)}: Returns the solution to the original problem given the inverse_data.
+
 }}
-

--- a/man/GeoMean-class.Rd
+++ b/man/GeoMean-class.Rd
@@ -80,35 +80,35 @@ A specific case of this is when \eqn{x \in \mathbf{R}^1}.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The (weighted) geometric mean of the elements of \code{x}.
+\item \code{to_numeric(GeoMean)}: The (weighted) geometric mean of the elements of \code{x}.
 
-\item \code{.domain}: Returns constraints describing the domain of the node
+\item \code{.domain(GeoMean)}: Returns constraints describing the domain of the node
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(GeoMean)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{name}: The name and arguments of the atom.
+\item \code{name(GeoMean)}: The name and arguments of the atom.
 
-\item \code{dim_from_args}: The atom is a scalar.
+\item \code{dim_from_args(GeoMean)}: The atom is a scalar.
 
-\item \code{sign_from_args}: The atom is non-negative.
+\item \code{sign_from_args(GeoMean)}: The atom is non-negative.
 
-\item \code{is_atom_convex}: The atom is not convex.
+\item \code{is_atom_convex(GeoMean)}: The atom is not convex.
 
-\item \code{is_atom_concave}: The atom is concave.
+\item \code{is_atom_concave(GeoMean)}: The atom is concave.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(GeoMean)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(GeoMean)}: Is the atom log-log concave?
 
-\item \code{is_incr}: The atom is weakly increasing in every argument.
+\item \code{is_incr(GeoMean)}: The atom is weakly increasing in every argument.
 
-\item \code{is_decr}: The atom is not weakly decreasing in any argument.
+\item \code{is_decr(GeoMean)}: The atom is not weakly decreasing in any argument.
 
-\item \code{get_data}: Returns \code{list(w, dyadic completion, tree of dyads)}.
+\item \code{get_data(GeoMean)}: Returns \code{list(w, dyadic completion, tree of dyads)}.
 
-\item \code{copy}: Returns a shallow copy of the GeoMean atom
+\item \code{copy(GeoMean)}: Returns a shallow copy of the GeoMean atom
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/HStack-class.Rd
+++ b/man/HStack-class.Rd
@@ -45,19 +45,19 @@ Horizontal concatenation of values.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Horizontally concatenate the values using \code{cbind}.
+\item \code{to_numeric(HStack)}: Horizontally concatenate the values using \code{cbind}.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(HStack)}: The dimensions of the atom.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(HStack)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(HStack)}: Is the atom log-log concave?
 
-\item \code{validate_args}: Check all arguments have the same height.
+\item \code{validate_args(HStack)}: Check all arguments have the same height.
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(HStack)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Huber-class.Rd
+++ b/man/Huber-class.Rd
@@ -59,27 +59,27 @@ This class represents the elementwise Huber function, \eqn{Huber(x, M) = }
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The Huber function evaluted elementwise on the input value.
+\item \code{to_numeric(Huber)}: The Huber function evaluted elementwise on the input value.
 
-\item \code{sign_from_args}: The atom is positive.
+\item \code{sign_from_args(Huber)}: The atom is positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(Huber)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(Huber)}: The atom is not concave.
 
-\item \code{is_incr}: A logical value indicating whether the atom is weakly increasing.
+\item \code{is_incr(Huber)}: A logical value indicating whether the atom is weakly increasing.
 
-\item \code{is_decr}: A logical value indicating whether the atom is weakly decreasing.
+\item \code{is_decr(Huber)}: A logical value indicating whether the atom is weakly decreasing.
 
-\item \code{is_quadratic}: The atom is quadratic if \code{x} is affine.
+\item \code{is_quadratic(Huber)}: The atom is quadratic if \code{x} is affine.
 
-\item \code{get_data}: A list containing the parameter \code{M}.
+\item \code{get_data(Huber)}: A list containing the parameter \code{M}.
 
-\item \code{validate_args}: Check that \code{M} is a non-negative constant.
+\item \code{validate_args(Huber)}: Check that \code{M} is a non-negative constant.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(Huber)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Imag-class.Rd
+++ b/man/Imag-class.Rd
@@ -36,17 +36,17 @@ This class represents the imaginary part of an expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The imaginary part of the given value.
+\item \code{to_numeric(Imag)}: The imaginary part of the given value.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(Imag)}: The dimensions of the atom.
 
-\item \code{is_imag}: Is the atom imaginary?
+\item \code{is_imag(Imag)}: Is the atom imaginary?
 
-\item \code{is_complex}: Is the atom complex valued?
+\item \code{is_complex(Imag)}: Is the atom complex valued?
 
-\item \code{is_symmetric}: Is the atom symmetric?
+\item \code{is_symmetric(Imag)}: Is the atom symmetric?
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Index-class.Rd
+++ b/man/Index-class.Rd
@@ -73,23 +73,23 @@ This class represents indexing or slicing into a matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The index/slice into the given value.
+\item \code{to_numeric(Index)}: The index/slice into the given value.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(Index)}: The dimensions of the atom.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Index)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Index)}: Is the atom log-log concave?
 
-\item \code{get_data}: A list containing \code{key}.
+\item \code{get_data(Index)}: A list containing \code{key}.
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(Index)}: The graph implementation of the atom.
 
-\item \code{to_numeric}: The index/slice into the given value.
+\item \code{to_numeric(SpecialIndex)}: The index/slice into the given value.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(SpecialIndex)}: The dimensions of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/IneqConstraint-class.Rd
+++ b/man/IneqConstraint-class.Rd
@@ -73,18 +73,18 @@ The IneqConstraint class
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The string representation of the constraint.
+\item \code{name(IneqConstraint)}: The string representation of the constraint.
 
-\item \code{dim}: The dimensions of the constrained expression.
+\item \code{dim(IneqConstraint)}: The dimensions of the constrained expression.
 
-\item \code{size}: The size of the constrained expression.
+\item \code{size(IneqConstraint)}: The size of the constrained expression.
 
-\item \code{expr}: The expression to constrain.
+\item \code{expr(IneqConstraint)}: The expression to constrain.
 
-\item \code{is_dcp}: A non-positive constraint is DCP if its argument is convex.
+\item \code{is_dcp(IneqConstraint)}: A non-positive constraint is DCP if its argument is convex.
 
-\item \code{is_dgp}: Is the constraint DGP?
+\item \code{is_dgp(IneqConstraint)}: Is the constraint DGP?
 
-\item \code{residual}: The residual of the constraint.
+\item \code{residual(IneqConstraint)}: The residual of the constraint.
+
 }}
-

--- a/man/KLDiv-class.Rd
+++ b/man/KLDiv-class.Rd
@@ -49,23 +49,23 @@ The elementwise KL-divergence \eqn{x\log(x/y) - x + y}.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The KL-divergence evaluted elementwise on the input value.
+\item \code{to_numeric(KLDiv)}: The KL-divergence evaluted elementwise on the input value.
 
-\item \code{sign_from_args}: The atom is positive.
+\item \code{sign_from_args(KLDiv)}: The atom is positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(KLDiv)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(KLDiv)}: The atom is not concave.
 
-\item \code{is_incr}: The atom is not monotonic in any argument.
+\item \code{is_incr(KLDiv)}: The atom is not monotonic in any argument.
 
-\item \code{is_decr}: The atom is not monotonic in any argument.
+\item \code{is_decr(KLDiv)}: The atom is not monotonic in any argument.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(KLDiv)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.domain}: Returns constraints describng the domain of the node
+\item \code{.domain(KLDiv)}: Returns constraints describng the domain of the node
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Kron-class.Rd
+++ b/man/Kron-class.Rd
@@ -52,21 +52,21 @@ This class represents the kronecker product.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The kronecker product of the two values.
+\item \code{to_numeric(Kron)}: The kronecker product of the two values.
 
-\item \code{validate_args}: Check both arguments are vectors and the first is a constant.
+\item \code{validate_args(Kron)}: Check both arguments are vectors and the first is a constant.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(Kron)}: The dimensions of the atom.
 
-\item \code{sign_from_args}: The sign of the atom.
+\item \code{sign_from_args(Kron)}: The sign of the atom.
 
-\item \code{is_incr}: Is the left-hand expression positive?
+\item \code{is_incr(Kron)}: Is the left-hand expression positive?
 
-\item \code{is_decr}: Is the right-hand expression negative?
+\item \code{is_decr(Kron)}: Is the right-hand expression negative?
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(Kron)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/LambdaMax-class.Rd
+++ b/man/LambdaMax-class.Rd
@@ -53,27 +53,27 @@ The maximum eigenvalue of a matrix, \eqn{\lambda_{\max}(A)}.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The largest eigenvalue of \code{A}. Requires that \code{A} be symmetric.
+\item \code{to_numeric(LambdaMax)}: The largest eigenvalue of \code{A}. Requires that \code{A} be symmetric.
 
-\item \code{.domain}: Returns the constraints describing the domain of the atom.
+\item \code{.domain(LambdaMax)}: Returns the constraints describing the domain of the atom.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom with respect to each argument. Matrix expressions are vectorized, so the gradient is a matrix.
+\item \code{.grad(LambdaMax)}: Gives the (sub/super)gradient of the atom with respect to each argument. Matrix expressions are vectorized, so the gradient is a matrix.
 
-\item \code{validate_args}: Check that \code{A} is square.
+\item \code{validate_args(LambdaMax)}: Check that \code{A} is square.
 
-\item \code{dim_from_args}: The atom is a scalar.
+\item \code{dim_from_args(LambdaMax)}: The atom is a scalar.
 
-\item \code{sign_from_args}: The sign of the atom is unknown.
+\item \code{sign_from_args(LambdaMax)}: The sign of the atom is unknown.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(LambdaMax)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(LambdaMax)}: The atom is not concave.
 
-\item \code{is_incr}: The atom is not monotonic in any argument.
+\item \code{is_incr(LambdaMax)}: The atom is not monotonic in any argument.
 
-\item \code{is_decr}: The atom is not monotonic in any argument.
+\item \code{is_decr(LambdaMax)}: The atom is not monotonic in any argument.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/LambdaSumLargest-class.Rd
+++ b/man/LambdaSumLargest-class.Rd
@@ -38,17 +38,17 @@ This class represents the sum of the \code{k} largest eigenvalues of a matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(LambdaSumLargest)}: Does the atom handle complex numbers?
 
-\item \code{to_numeric}: Returns the largest eigenvalue of \code{A}, which must be symmetric.
+\item \code{to_numeric(LambdaSumLargest)}: Returns the largest eigenvalue of \code{A}, which must be symmetric.
 
-\item \code{validate_args}: Verify that the argument \code{A} is square.
+\item \code{validate_args(LambdaSumLargest)}: Verify that the argument \code{A} is square.
 
-\item \code{get_data}: Returns the parameter \code{k}.
+\item \code{get_data(LambdaSumLargest)}: Returns the parameter \code{k}.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(LambdaSumLargest)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Leaf-class.Rd
+++ b/man/Leaf-class.Rd
@@ -102,63 +102,63 @@ This class represents a leaf node, i.e. a Variable, Constant, or Parameter.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{get_data}: Leaves are not copied.
+\item \code{get_data(Leaf)}: Leaves are not copied.
 
-\item \code{dim}: The dimensions of the leaf node.
+\item \code{dim(Leaf)}: The dimensions of the leaf node.
 
-\item \code{variables}: List of \linkS4class{Variable} objects in the leaf node.
+\item \code{variables(Leaf)}: List of \linkS4class{Variable} objects in the leaf node.
 
-\item \code{parameters}: List of \linkS4class{Parameter} objects in the leaf node.
+\item \code{parameters(Leaf)}: List of \linkS4class{Parameter} objects in the leaf node.
 
-\item \code{constants}: List of \linkS4class{Constant} objects in the leaf node.
+\item \code{constants(Leaf)}: List of \linkS4class{Constant} objects in the leaf node.
 
-\item \code{atoms}: List of \linkS4class{Atom} objects in the leaf node.
+\item \code{atoms(Leaf)}: List of \linkS4class{Atom} objects in the leaf node.
 
-\item \code{is_convex}: A logical value indicating whether the leaf node is convex.
+\item \code{is_convex(Leaf)}: A logical value indicating whether the leaf node is convex.
 
-\item \code{is_concave}: A logical value indicating whether the leaf node is concave.
+\item \code{is_concave(Leaf)}: A logical value indicating whether the leaf node is concave.
 
-\item \code{is_log_log_convex}: Is the expression log-log convex?
+\item \code{is_log_log_convex(Leaf)}: Is the expression log-log convex?
 
-\item \code{is_log_log_concave}: Is the expression log-log concave?
+\item \code{is_log_log_concave(Leaf)}: Is the expression log-log concave?
 
-\item \code{is_nonneg}: A logical value indicating whether the leaf node is nonnegative.
+\item \code{is_nonneg(Leaf)}: A logical value indicating whether the leaf node is nonnegative.
 
-\item \code{is_nonpos}: A logical value indicating whether the leaf node is nonpositive.
+\item \code{is_nonpos(Leaf)}: A logical value indicating whether the leaf node is nonpositive.
 
-\item \code{is_pos}: Is the expression positive?
+\item \code{is_pos(Leaf)}: Is the expression positive?
 
-\item \code{is_neg}: Is the expression negative?
+\item \code{is_neg(Leaf)}: Is the expression negative?
 
-\item \code{is_hermitian}: A logical value indicating whether the leaf node is hermitian.
+\item \code{is_hermitian(Leaf)}: A logical value indicating whether the leaf node is hermitian.
 
-\item \code{is_symmetric}: A logical value indicating whether the leaf node is symmetric.
+\item \code{is_symmetric(Leaf)}: A logical value indicating whether the leaf node is symmetric.
 
-\item \code{is_imag}: A logical value indicating whether the leaf node is imaginary.
+\item \code{is_imag(Leaf)}: A logical value indicating whether the leaf node is imaginary.
 
-\item \code{is_complex}: A logical value indicating whether the leaf node is complex.
+\item \code{is_complex(Leaf)}: A logical value indicating whether the leaf node is complex.
 
-\item \code{domain}: A list of constraints describing the closure of the region where the leaf node is finite. Default is the full domain.
+\item \code{domain(Leaf)}: A list of constraints describing the closure of the region where the leaf node is finite. Default is the full domain.
 
-\item \code{project}: Project value onto the attribute set of the leaf.
+\item \code{project(Leaf)}: Project value onto the attribute set of the leaf.
 
-\item \code{project_and_assign}: Project and assign a value to the leaf.
+\item \code{project_and_assign(Leaf)}: Project and assign a value to the leaf.
 
-\item \code{value}: Get the value of the leaf.
+\item \code{value(Leaf)}: Get the value of the leaf.
 
-\item \code{value<-}: Set the value of the leaf.
+\item \code{value(Leaf) <- value}: Set the value of the leaf.
 
-\item \code{validate_val}: Check that \code{val} satisfies symbolic attributes of leaf.
+\item \code{validate_val(Leaf)}: Check that \code{val} satisfies symbolic attributes of leaf.
 
-\item \code{is_psd}: A logical value indicating whether the leaf node is a positive semidefinite matrix.
+\item \code{is_psd(Leaf)}: A logical value indicating whether the leaf node is a positive semidefinite matrix.
 
-\item \code{is_nsd}: A logical value indicating whether the leaf node is a negative semidefinite matrix.
+\item \code{is_nsd(Leaf)}: A logical value indicating whether the leaf node is a negative semidefinite matrix.
 
-\item \code{is_quadratic}: Leaf nodes are always quadratic.
+\item \code{is_quadratic(Leaf)}: Leaf nodes are always quadratic.
 
-\item \code{is_pwl}: Leaf nodes are always piecewise linear.
+\item \code{is_pwl(Leaf)}: Leaf nodes are always piecewise linear.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/ListORConstr-class.Rd
+++ b/man/ListORConstr-class.Rd
@@ -16,6 +16,6 @@ A Class Union of List and Constraint
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{id}: Returns the ID associated with the list or constraint.
-}}
+\item \code{id(ListORConstr)}: Returns the ID associated with the list or constraint.
 
+}}

--- a/man/Log-class.Rd
+++ b/man/Log-class.Rd
@@ -53,27 +53,27 @@ This class represents the elementwise natural logarithm \eqn{\log(x)}.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The elementwise natural logarithm of the input value.
+\item \code{to_numeric(Log)}: The elementwise natural logarithm of the input value.
 
-\item \code{sign_from_args}: The sign of the atom is unknown.
+\item \code{sign_from_args(Log)}: The sign of the atom is unknown.
 
-\item \code{is_atom_convex}: The atom is not convex.
+\item \code{is_atom_convex(Log)}: The atom is not convex.
 
-\item \code{is_atom_concave}: The atom is concave.
+\item \code{is_atom_concave(Log)}: The atom is concave.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Log)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Log)}: Is the atom log-log concave?
 
-\item \code{is_incr}: The atom is weakly increasing.
+\item \code{is_incr(Log)}: The atom is weakly increasing.
 
-\item \code{is_decr}: The atom is not weakly decreasing.
+\item \code{is_decr(Log)}: The atom is not weakly decreasing.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(Log)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.domain}: Returns constraints describng the domain of the node
+\item \code{.domain(Log)}: Returns constraints describng the domain of the node
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Log1p-class.Rd
+++ b/man/Log1p-class.Rd
@@ -33,15 +33,15 @@ This class represents the elementwise operation \eqn{\log(1 + x)}.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The elementwise natural logarithm of one plus the input value.
+\item \code{to_numeric(Log1p)}: The elementwise natural logarithm of one plus the input value.
 
-\item \code{sign_from_args}: The sign of the atom.
+\item \code{sign_from_args(Log1p)}: The sign of the atom.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(Log1p)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.domain}: Returns constraints describng the domain of the node
+\item \code{.domain(Log1p)}: Returns constraints describng the domain of the node
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/LogDet-class.Rd
+++ b/man/LogDet-class.Rd
@@ -53,27 +53,27 @@ The natural logarithm of the determinant of a matrix, \eqn{\log\det(A)}.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The log-determinant of SDP matrix \code{A}. This is the sum of logs of the eigenvalues and is equivalent to the nuclear norm of the matrix logarithm of \code{A}.
+\item \code{to_numeric(LogDet)}: The log-determinant of SDP matrix \code{A}. This is the sum of logs of the eigenvalues and is equivalent to the nuclear norm of the matrix logarithm of \code{A}.
 
-\item \code{validate_args}: Check that \code{A} is square.
+\item \code{validate_args(LogDet)}: Check that \code{A} is square.
 
-\item \code{dim_from_args}: The atom is a scalar.
+\item \code{dim_from_args(LogDet)}: The atom is a scalar.
 
-\item \code{sign_from_args}: The atom is non-negative.
+\item \code{sign_from_args(LogDet)}: The atom is non-negative.
 
-\item \code{is_atom_convex}: The atom is not convex.
+\item \code{is_atom_convex(LogDet)}: The atom is not convex.
 
-\item \code{is_atom_concave}: The atom is concave.
+\item \code{is_atom_concave(LogDet)}: The atom is concave.
 
-\item \code{is_incr}: The atom is not monotonic in any argument.
+\item \code{is_incr(LogDet)}: The atom is not monotonic in any argument.
 
-\item \code{is_decr}: The atom is not monotonic in any argument.
+\item \code{is_decr(LogDet)}: The atom is not monotonic in any argument.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(LogDet)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.domain}: Returns constraints describing the domain of the node
+\item \code{.domain(LogDet)}: Returns constraints describing the domain of the node
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/LogSumExp-class.Rd
+++ b/man/LogSumExp-class.Rd
@@ -53,23 +53,23 @@ The natural logarithm of the sum of the elementwise exponential, \eqn{\log\sum_{
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Evaluates \eqn{e^x} elementwise, sums, and takes the natural log.
+\item \code{to_numeric(LogSumExp)}: Evaluates \eqn{e^x} elementwise, sums, and takes the natural log.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(LogSumExp)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.column_grad}: Gives the (sub/super)gradient of the atom w.r.t. each column variable.
+\item \code{.column_grad(LogSumExp)}: Gives the (sub/super)gradient of the atom w.r.t. each column variable.
 
-\item \code{sign_from_args}: Returns sign (is positive, is negative) of the atom.
+\item \code{sign_from_args(LogSumExp)}: Returns sign (is positive, is negative) of the atom.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(LogSumExp)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(LogSumExp)}: The atom is not concave.
 
-\item \code{is_incr}: The atom is weakly increasing in the index.
+\item \code{is_incr(LogSumExp)}: The atom is weakly increasing in the index.
 
-\item \code{is_decr}: The atom is not weakly decreasing in the index.
+\item \code{is_decr(LogSumExp)}: The atom is not weakly decreasing in the index.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Logistic-class.Rd
+++ b/man/Logistic-class.Rd
@@ -46,21 +46,21 @@ which is useful for logistic regression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Evaluates \code{e^x} elementwise, adds one, and takes the natural logarithm.
+\item \code{to_numeric(Logistic)}: Evaluates \code{e^x} elementwise, adds one, and takes the natural logarithm.
 
-\item \code{sign_from_args}: The atom is positive.
+\item \code{sign_from_args(Logistic)}: The atom is positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(Logistic)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(Logistic)}: The atom is not concave.
 
-\item \code{is_incr}: The atom is weakly increasing.
+\item \code{is_incr(Logistic)}: The atom is weakly increasing.
 
-\item \code{is_decr}: The atom is not weakly decreasing.
+\item \code{is_decr(Logistic)}: The atom is not weakly decreasing.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(Logistic)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/MOSEK-class.Rd
+++ b/man/MOSEK-class.Rd
@@ -81,24 +81,24 @@ An interface for the MOSEK solver.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(MOSEK)}: Can the solver handle mixed-integer programs?
 
-\item \code{import_solver}: Imports the solver.
+\item \code{import_solver(MOSEK)}: Imports the solver.
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(MOSEK)}: Returns the name of the solver.
 
-\item \code{accepts}: Can MOSEK solve the problem?
+\item \code{accepts(object = MOSEK, problem = Problem)}: Can MOSEK solve the problem?
 
-\item \code{block_format}: Returns a large matrix "coeff" and a vector of constants "offset" such
+\item \code{block_format(MOSEK)}: Returns a large matrix "coeff" and a vector of constants "offset" such
 that every \linkS4class{Constraint} in "constraints" holds at z in R^n iff
 "coeff" * z <=_K offset", where K is a product of cones supported by MOSEK
 and CVXR (zero cone, nonnegative orthant, second order cone, exponential cone). The
 nature of K is inferred later by accessing the data in "lengths" and "ids".
 
-\item \code{perform}: Returns a new problem and data for inverting the new solution.
+\item \code{perform(object = MOSEK, problem = Problem)}: Returns a new problem and data for inverting the new solution.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(MOSEK)}: Solve a problem represented by data returned from apply.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = MOSEK, solution = ANY, inverse_data = ANY)}: Returns the solution to the original problem given the inverse_data.
+
 }}
-

--- a/man/MatrixFrac-class.Rd
+++ b/man/MatrixFrac-class.Rd
@@ -64,33 +64,33 @@ The matrix fraction function \eqn{tr(X^T P^{-1} X)}.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(MatrixFrac)}: Does the atom handle complex numbers?
 
-\item \code{to_numeric}: The trace of \eqn{X^TP^{-1}X}.
+\item \code{to_numeric(MatrixFrac)}: The trace of \eqn{X^TP^{-1}X}.
 
-\item \code{validate_args}: Check that the dimensions of \code{x} and \code{P} match.
+\item \code{validate_args(MatrixFrac)}: Check that the dimensions of \code{x} and \code{P} match.
 
-\item \code{dim_from_args}: The atom is a scalar.
+\item \code{dim_from_args(MatrixFrac)}: The atom is a scalar.
 
-\item \code{sign_from_args}: The atom is positive.
+\item \code{sign_from_args(MatrixFrac)}: The atom is positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(MatrixFrac)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(MatrixFrac)}: The atom is not concave.
 
-\item \code{is_incr}: The atom is not monotonic in any argument.
+\item \code{is_incr(MatrixFrac)}: The atom is not monotonic in any argument.
 
-\item \code{is_decr}: The atom is not monotonic in any argument.
+\item \code{is_decr(MatrixFrac)}: The atom is not monotonic in any argument.
 
-\item \code{is_quadratic}: True if x is affine and P is constant.
+\item \code{is_quadratic(MatrixFrac)}: True if x is affine and P is constant.
 
-\item \code{is_qpwa}: True if x is piecewise linear and P is constant.
+\item \code{is_qpwa(MatrixFrac)}: True if x is piecewise linear and P is constant.
 
-\item \code{.domain}: Returns constraints describing the domain of the node
+\item \code{.domain(MatrixFrac)}: Returns constraints describing the domain of the node
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(MatrixFrac)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/MatrixStuffing-class.Rd
+++ b/man/MatrixStuffing-class.Rd
@@ -26,9 +26,13 @@ The MatrixStuffing class.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{perform}: Returns a stuffed problem. The returned problem is a minimization problem in which every
+\item \code{perform(object = MatrixStuffing, problem = Problem)}: Returns a stuffed problem. The returned problem is a minimization problem in which every
 constraint in the problem has affine arguments that are expressed in the form A %*% x + b.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
-}}
+\item \code{invert(
+  object = MatrixStuffing,
+  solution = Solution,
+  inverse_data = InverseData
+)}: Returns the solution to the original problem given the inverse_data.
 
+}}

--- a/man/MaxElemwise-class.Rd
+++ b/man/MaxElemwise-class.Rd
@@ -57,27 +57,27 @@ This class represents the elementwise maximum.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The elementwise maximum.
+\item \code{to_numeric(MaxElemwise)}: The elementwise maximum.
 
-\item \code{sign_from_args}: The sign of the atom.
+\item \code{sign_from_args(MaxElemwise)}: The sign of the atom.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(MaxElemwise)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(MaxElemwise)}: The atom is not concave.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(MaxElemwise)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(MaxElemwise)}: Is the atom log-log concave?
 
-\item \code{is_incr}: The atom is weakly increasing.
+\item \code{is_incr(MaxElemwise)}: The atom is weakly increasing.
 
-\item \code{is_decr}: The atom is not weakly decreasing.
+\item \code{is_decr(MaxElemwise)}: The atom is not weakly decreasing.
 
-\item \code{is_pwl}: Are all the arguments piecewise linear?
+\item \code{is_pwl(MaxElemwise)}: Are all the arguments piecewise linear?
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(MaxElemwise)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/MaxEntries-class.Rd
+++ b/man/MaxEntries-class.Rd
@@ -62,29 +62,29 @@ The maximum of an expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The largest entry in \code{x}.
+\item \code{to_numeric(MaxEntries)}: The largest entry in \code{x}.
 
-\item \code{sign_from_args}: The sign of the atom.
+\item \code{sign_from_args(MaxEntries)}: The sign of the atom.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(MaxEntries)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(MaxEntries)}: The atom is not concave.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex.
+\item \code{is_atom_log_log_convex(MaxEntries)}: Is the atom log-log convex.
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave.
+\item \code{is_atom_log_log_concave(MaxEntries)}: Is the atom log-log concave.
 
-\item \code{is_incr}: The atom is weakly increasing in every argument.
+\item \code{is_incr(MaxEntries)}: The atom is weakly increasing in every argument.
 
-\item \code{is_decr}: The atom is not weakly decreasing in any argument.
+\item \code{is_decr(MaxEntries)}: The atom is not weakly decreasing in any argument.
 
-\item \code{is_pwl}: Is \code{x} piecewise linear?
+\item \code{is_pwl(MaxEntries)}: Is \code{x} piecewise linear?
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(MaxEntries)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.column_grad}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+\item \code{.column_grad(MaxEntries)}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Maximize-class.Rd
+++ b/man/Maximize-class.Rd
@@ -28,13 +28,13 @@ This class represents an optimization objective for maximization.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{canonicalize}: Negates the target expression's objective.
+\item \code{canonicalize(Maximize)}: Negates the target expression's objective.
 
-\item \code{is_dcp}: A logical value indicating whether the objective is concave.
+\item \code{is_dcp(Maximize)}: A logical value indicating whether the objective is concave.
 
-\item \code{is_dgp}: A logical value indicating whether the objective is log-log concave.
+\item \code{is_dgp(Maximize)}: A logical value indicating whether the objective is log-log concave.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/MinElemwise-class.Rd
+++ b/man/MinElemwise-class.Rd
@@ -57,27 +57,27 @@ This class represents the elementwise minimum.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The elementwise minimum.
+\item \code{to_numeric(MinElemwise)}: The elementwise minimum.
 
-\item \code{sign_from_args}: The sign of the atom.
+\item \code{sign_from_args(MinElemwise)}: The sign of the atom.
 
-\item \code{is_atom_convex}: The atom is not convex.
+\item \code{is_atom_convex(MinElemwise)}: The atom is not convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(MinElemwise)}: The atom is not concave.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(MinElemwise)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(MinElemwise)}: Is the atom log-log concave?
 
-\item \code{is_incr}: The atom is weakly increasing.
+\item \code{is_incr(MinElemwise)}: The atom is weakly increasing.
 
-\item \code{is_decr}: The atom is not weakly decreasing.
+\item \code{is_decr(MinElemwise)}: The atom is not weakly decreasing.
 
-\item \code{is_pwl}: Are all the arguments piecewise linear?
+\item \code{is_pwl(MinElemwise)}: Are all the arguments piecewise linear?
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(MinElemwise)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/MinEntries-class.Rd
+++ b/man/MinEntries-class.Rd
@@ -62,29 +62,29 @@ The minimum of an expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The largest entry in \code{x}.
+\item \code{to_numeric(MinEntries)}: The largest entry in \code{x}.
 
-\item \code{sign_from_args}: The sign of the atom.
+\item \code{sign_from_args(MinEntries)}: The sign of the atom.
 
-\item \code{is_atom_convex}: The atom is not convex.
+\item \code{is_atom_convex(MinEntries)}: The atom is not convex.
 
-\item \code{is_atom_concave}: The atom is concave.
+\item \code{is_atom_concave(MinEntries)}: The atom is concave.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(MinEntries)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(MinEntries)}: Is the atom log-log concave?
 
-\item \code{is_incr}: The atom is weakly increasing in every argument.
+\item \code{is_incr(MinEntries)}: The atom is weakly increasing in every argument.
 
-\item \code{is_decr}: The atom is not weakly decreasing in any argument.
+\item \code{is_decr(MinEntries)}: The atom is not weakly decreasing in any argument.
 
-\item \code{is_pwl}: Is \code{x} piecewise linear?
+\item \code{is_pwl(MinEntries)}: Is \code{x} piecewise linear?
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(MinEntries)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.column_grad}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+\item \code{.column_grad(MinEntries)}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Minimize-class.Rd
+++ b/man/Minimize-class.Rd
@@ -28,13 +28,13 @@ This class represents an optimization objective for minimization.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{canonicalize}: Pass on the target expression's objective and constraints.
+\item \code{canonicalize(Minimize)}: Pass on the target expression's objective and constraints.
 
-\item \code{is_dcp}: A logical value indicating whether the objective is convex.
+\item \code{is_dcp(Minimize)}: A logical value indicating whether the objective is convex.
 
-\item \code{is_dgp}: A logical value indicating whether the objective is log-log convex.
+\item \code{is_dgp(Minimize)}: A logical value indicating whether the objective is log-log convex.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/MulExpression-class.Rd
+++ b/man/MulExpression-class.Rd
@@ -67,27 +67,27 @@ See \linkS4class{Multiply} for the elementwise product.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Matrix multiplication.
+\item \code{to_numeric(MulExpression)}: Matrix multiplication.
 
-\item \code{dim_from_args}: The (row, col) dimensions of the expression.
+\item \code{dim_from_args(MulExpression)}: The (row, col) dimensions of the expression.
 
-\item \code{is_atom_convex}: Multiplication is convex (affine) in its arguments only if one of the arguments is constant.
+\item \code{is_atom_convex(MulExpression)}: Multiplication is convex (affine) in its arguments only if one of the arguments is constant.
 
-\item \code{is_atom_concave}: If the multiplication atom is convex, then it is affine.
+\item \code{is_atom_concave(MulExpression)}: If the multiplication atom is convex, then it is affine.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(MulExpression)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(MulExpression)}: Is the atom log-log concave?
 
-\item \code{is_incr}: Is the left-hand expression positive?
+\item \code{is_incr(MulExpression)}: Is the left-hand expression positive?
 
-\item \code{is_decr}: Is the left-hand expression negative?
+\item \code{is_decr(MulExpression)}: Is the left-hand expression negative?
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(MulExpression)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{graph_implementation}: The graph implementation of the expression.
+\item \code{graph_implementation(MulExpression)}: The graph implementation of the expression.
+
 }}
-
 \seealso{
 \linkS4class{Multiply}
 }

--- a/man/Multiply-class.Rd
+++ b/man/Multiply-class.Rd
@@ -50,18 +50,18 @@ This class represents the elementwise product of two expressions.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Multiplies the values elementwise.
+\item \code{to_numeric(Multiply)}: Multiplies the values elementwise.
 
-\item \code{dim_from_args}: The sum of the argument dimensions - 1.
+\item \code{dim_from_args(Multiply)}: The sum of the argument dimensions - 1.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Multiply)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Multiply)}: Is the atom log-log concave?
 
-\item \code{is_psd}: Is the expression a positive semidefinite matrix?
+\item \code{is_psd(Multiply)}: Is the expression a positive semidefinite matrix?
 
-\item \code{is_nsd}: Is the expression a negative semidefinite matrix?
+\item \code{is_nsd(Multiply)}: Is the expression a negative semidefinite matrix?
 
-\item \code{graph_implementation}: The graph implementation of the expression.
+\item \code{graph_implementation(Multiply)}: The graph implementation of the expression.
+
 }}
-

--- a/man/NegExpression-class.Rd
+++ b/man/NegExpression-class.Rd
@@ -58,18 +58,18 @@ This class represents the negation of an affine expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{dim_from_args}: The (row, col) dimensions of the expression.
+\item \code{dim_from_args(NegExpression)}: The (row, col) dimensions of the expression.
 
-\item \code{sign_from_args}: The (is positive, is negative) sign of the expression.
+\item \code{sign_from_args(NegExpression)}: The (is positive, is negative) sign of the expression.
 
-\item \code{is_incr}: The expression is not weakly increasing in any argument.
+\item \code{is_incr(NegExpression)}: The expression is not weakly increasing in any argument.
 
-\item \code{is_decr}: The expression is weakly decreasing in every argument.
+\item \code{is_decr(NegExpression)}: The expression is weakly decreasing in every argument.
 
-\item \code{is_symmetric}: Is the expression symmetric?
+\item \code{is_symmetric(NegExpression)}: Is the expression symmetric?
 
-\item \code{is_hermitian}: Is the expression Hermitian?
+\item \code{is_hermitian(NegExpression)}: Is the expression Hermitian?
 
-\item \code{graph_implementation}: The graph implementation of the expression.
+\item \code{graph_implementation(NegExpression)}: The graph implementation of the expression.
+
 }}
-

--- a/man/NonPosConstraint-class.Rd
+++ b/man/NonPosConstraint-class.Rd
@@ -29,14 +29,14 @@ The NonPosConstraint class
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The string representation of the constraint.
+\item \code{name(NonPosConstraint)}: The string representation of the constraint.
 
-\item \code{is_dcp}: Is the constraint DCP?
+\item \code{is_dcp(NonPosConstraint)}: Is the constraint DCP?
 
-\item \code{is_dgp}: Is the constraint DGP?
+\item \code{is_dgp(NonPosConstraint)}: Is the constraint DGP?
 
-\item \code{canonicalize}: The graph implementation of the object.
+\item \code{canonicalize(NonPosConstraint)}: The graph implementation of the object.
 
-\item \code{residual}: The residual of the constraint.
+\item \code{residual(NonPosConstraint)}: The residual of the constraint.
+
 }}
-

--- a/man/Norm1-class.Rd
+++ b/man/Norm1-class.Rd
@@ -68,33 +68,33 @@ This class represents the 1-norm of an expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The name and arguments of the atom.
+\item \code{name(Norm1)}: The name and arguments of the atom.
 
-\item \code{to_numeric}: Returns the 1-norm of x along the given axis.
+\item \code{to_numeric(Norm1)}: Returns the 1-norm of x along the given axis.
 
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(Norm1)}: Does the atom handle complex numbers?
 
-\item \code{sign_from_args}: The atom is always positive.
+\item \code{sign_from_args(Norm1)}: The atom is always positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(Norm1)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(Norm1)}: The atom is not concave.
 
-\item \code{is_incr}: Is the composition weakly increasing in argument \code{idx}?
+\item \code{is_incr(Norm1)}: Is the composition weakly increasing in argument \code{idx}?
 
-\item \code{is_decr}: Is the composition weakly decreasing in argument \code{idx}?
+\item \code{is_decr(Norm1)}: Is the composition weakly decreasing in argument \code{idx}?
 
-\item \code{is_pwl}: Is the atom piecewise linear?
+\item \code{is_pwl(Norm1)}: Is the atom piecewise linear?
 
-\item \code{get_data}: Returns the axis.
+\item \code{get_data(Norm1)}: Returns the axis.
 
-\item \code{.domain}: Returns constraints describing the domain of the node
+\item \code{.domain(Norm1)}: Returns constraints describing the domain of the node
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(Norm1)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.column_grad}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+\item \code{.column_grad(Norm1)}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/NormInf-class.Rd
+++ b/man/NormInf-class.Rd
@@ -66,34 +66,34 @@ This class represents the infinity-norm.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The name and arguments of the atom.
+\item \code{name(NormInf)}: The name and arguments of the atom.
 
-\item \code{to_numeric}: Returns the infinity norm of \code{x}.
+\item \code{to_numeric(NormInf)}: Returns the infinity norm of \code{x}.
 
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(NormInf)}: Does the atom handle complex numbers?
 
-\item \code{sign_from_args}: The atom is always positive.
+\item \code{sign_from_args(NormInf)}: The atom is always positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(NormInf)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(NormInf)}: The atom is not concave.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(NormInf)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(NormInf)}: Is the atom log-log concave?
 
-\item \code{is_incr}: Is the composition weakly increasing in argument \code{idx}?
+\item \code{is_incr(NormInf)}: Is the composition weakly increasing in argument \code{idx}?
 
-\item \code{is_decr}: Is the composition weakly decreasing in argument \code{idx}?
+\item \code{is_decr(NormInf)}: Is the composition weakly decreasing in argument \code{idx}?
 
-\item \code{is_pwl}: Is the atom piecewise linear?
+\item \code{is_pwl(NormInf)}: Is the atom piecewise linear?
 
-\item \code{get_data}: Returns the axis.
+\item \code{get_data(NormInf)}: Returns the axis.
 
-\item \code{.domain}: Returns constraints describing the domain of the node
+\item \code{.domain(NormInf)}: Returns constraints describing the domain of the node
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(NormInf)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.column_grad}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+\item \code{.column_grad(NormInf)}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+
 }}
-

--- a/man/NormNuc-class.Rd
+++ b/man/NormNuc-class.Rd
@@ -50,25 +50,25 @@ The nuclear norm, i.e. sum of the singular values of a matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The nuclear norm (i.e., the sum of the singular values) of \code{A}.
+\item \code{to_numeric(NormNuc)}: The nuclear norm (i.e., the sum of the singular values) of \code{A}.
 
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(NormNuc)}: Does the atom handle complex numbers?
 
-\item \code{dim_from_args}: The atom is a scalar.
+\item \code{dim_from_args(NormNuc)}: The atom is a scalar.
 
-\item \code{sign_from_args}: The atom is positive.
+\item \code{sign_from_args(NormNuc)}: The atom is positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(NormNuc)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(NormNuc)}: The atom is not concave.
 
-\item \code{is_incr}: The atom is not monotonic in any argument.
+\item \code{is_incr(NormNuc)}: The atom is not monotonic in any argument.
 
-\item \code{is_decr}: The atom is not monotonic in any argument.
+\item \code{is_decr(NormNuc)}: The atom is not monotonic in any argument.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(NormNuc)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/OSQP-class.Rd
+++ b/man/OSQP-class.Rd
@@ -66,14 +66,14 @@ An interface for the OSQP solver.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{status_map}: Converts status returned by the OSQP solver to its respective CVXPY status.
+\item \code{status_map(OSQP)}: Converts status returned by the OSQP solver to its respective CVXPY status.
 
-\item \code{name}: Returns the name of the solver.
+\item \code{name(OSQP)}: Returns the name of the solver.
 
-\item \code{import_solver}: Imports the solver.
+\item \code{import_solver(OSQP)}: Imports the solver.
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = OSQP, solution = list, inverse_data = InverseData)}: Returns the solution to the original problem given the inverse_data.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(OSQP)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/Objective-class.Rd
+++ b/man/Objective-class.Rd
@@ -28,13 +28,13 @@ This class represents an optimization objective.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{value}: The value of the objective expression.
+\item \code{value(Objective)}: The value of the objective expression.
 
-\item \code{is_quadratic}: Is the objective a quadratic function?
+\item \code{is_quadratic(Objective)}: Is the objective a quadratic function?
 
-\item \code{is_qpwa}: Is the objective a quadratic of piecewise affine function?
+\item \code{is_qpwa(Objective)}: Is the objective a quadratic of piecewise affine function?
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/OneMinusPos-class.Rd
+++ b/man/OneMinusPos-class.Rd
@@ -56,29 +56,29 @@ This class represents the difference \eqn{1 - x} with domain \eqn{\{x : 0 < x < 
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The name and arguments of the atom.
+\item \code{name(OneMinusPos)}: The name and arguments of the atom.
 
-\item \code{to_numeric}: Returns one minus the value.
+\item \code{to_numeric(OneMinusPos)}: Returns one minus the value.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(OneMinusPos)}: The dimensions of the atom.
 
-\item \code{sign_from_args}: Returns the sign (is positive, is negative) of the atom.
+\item \code{sign_from_args(OneMinusPos)}: Returns the sign (is positive, is negative) of the atom.
 
-\item \code{is_atom_convex}: Is the atom convex?
+\item \code{is_atom_convex(OneMinusPos)}: Is the atom convex?
 
-\item \code{is_atom_concave}: Is the atom concave?
+\item \code{is_atom_concave(OneMinusPos)}: Is the atom concave?
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(OneMinusPos)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(OneMinusPos)}: Is the atom log-log concave?
 
-\item \code{is_incr}: Is the atom weakly increasing in the argument \code{idx}?
+\item \code{is_incr(OneMinusPos)}: Is the atom weakly increasing in the argument \code{idx}?
 
-\item \code{is_decr}: Is the atom weakly decreasing in the argument \code{idx}?
+\item \code{is_decr(OneMinusPos)}: Is the atom weakly decreasing in the argument \code{idx}?
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(OneMinusPos)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/PSDConstraint-class.Rd
+++ b/man/PSDConstraint-class.Rd
@@ -62,17 +62,17 @@ This class represents the positive semidefinite constraint, \eqn{\frac{1}{2}(X +
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The string representation of the constraint.
+\item \code{name(PSDConstraint)}: The string representation of the constraint.
 
-\item \code{is_dcp}: The constraint is DCP if the left-hand and right-hand expressions are affine.
+\item \code{is_dcp(PSDConstraint)}: The constraint is DCP if the left-hand and right-hand expressions are affine.
 
-\item \code{is_dgp}: Is the constraint DGP?
+\item \code{is_dgp(PSDConstraint)}: Is the constraint DGP?
 
-\item \code{residual}: A \linkS4class{Expression} representing the residual of the constraint.
+\item \code{residual(PSDConstraint)}: A \linkS4class{Expression} representing the residual of the constraint.
 
-\item \code{canonicalize}: The graph implementation of the object. Marks the top level constraint as the \code{dual_holder} so the dual value will be saved to the \linkS4class{PSDConstraint}.
+\item \code{canonicalize(PSDConstraint)}: The graph implementation of the object. Marks the top level constraint as the \code{dual_holder} so the dual value will be saved to the \linkS4class{PSDConstraint}.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/PSDWrap-class.Rd
+++ b/man/PSDWrap-class.Rd
@@ -22,6 +22,6 @@ A no-op wrapper to assert the input argument is positive semidefinite.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{is_psd}: Is the atom positive semidefinite?
-}}
+\item \code{is_psd(PSDWrap)}: Is the atom positive semidefinite?
 
+}}

--- a/man/Parameter-class.Rd
+++ b/man/Parameter-class.Rd
@@ -54,21 +54,21 @@ This class represents a parameter, either scalar or a matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{get_data}: Returns \code{list(dim, name, value, attributes)}.
+\item \code{get_data(Parameter)}: Returns \code{list(dim, name, value, attributes)}.
 
-\item \code{name}: The name of the parameter.
+\item \code{name(Parameter)}: The name of the parameter.
 
-\item \code{value}: The value of the parameter.
+\item \code{value(Parameter)}: The value of the parameter.
 
-\item \code{value<-}: Set the value of the parameter.
+\item \code{value(Parameter) <- value}: Set the value of the parameter.
 
-\item \code{grad}: An empty list since the gradient of a parameter is zero.
+\item \code{grad(Parameter)}: An empty list since the gradient of a parameter is zero.
 
-\item \code{parameters}: Returns itself as a parameter.
+\item \code{parameters(Parameter)}: Returns itself as a parameter.
 
-\item \code{canonicalize}: The canonical form of the parameter.
+\item \code{canonicalize(Parameter)}: The canonical form of the parameter.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/PfEigenvalue-class.Rd
+++ b/man/PfEigenvalue-class.Rd
@@ -56,29 +56,29 @@ This class represents the Perron-Frobenius eigenvalue of a positive matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The name and arguments of the atom.
+\item \code{name(PfEigenvalue)}: The name and arguments of the atom.
 
-\item \code{to_numeric}: Returns the Perron-Frobenius eigenvalue of \code{X}.
+\item \code{to_numeric(PfEigenvalue)}: Returns the Perron-Frobenius eigenvalue of \code{X}.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(PfEigenvalue)}: The dimensions of the atom.
 
-\item \code{sign_from_args}: Returns the sign (is positive, is negative) of the atom.
+\item \code{sign_from_args(PfEigenvalue)}: Returns the sign (is positive, is negative) of the atom.
 
-\item \code{is_atom_convex}: Is the atom convex?
+\item \code{is_atom_convex(PfEigenvalue)}: Is the atom convex?
 
-\item \code{is_atom_concave}: Is the atom concave?
+\item \code{is_atom_concave(PfEigenvalue)}: Is the atom concave?
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(PfEigenvalue)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(PfEigenvalue)}: Is the atom log-log concave?
 
-\item \code{is_incr}: Is the atom weakly increasing in the argument \code{idx}?
+\item \code{is_incr(PfEigenvalue)}: Is the atom weakly increasing in the argument \code{idx}?
 
-\item \code{is_decr}: Is the atom weakly decreasing in the argument \code{idx}?
+\item \code{is_decr(PfEigenvalue)}: Is the atom weakly decreasing in the argument \code{idx}?
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(PfEigenvalue)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Pnorm-class.Rd
+++ b/man/Pnorm-class.Rd
@@ -93,39 +93,39 @@ For \eqn{p < 1, p\neq 0}, the p-norm is given by \deqn{\|x\|_p = \left(\sum_{i=1
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(Pnorm)}: Does the atom handle complex numbers?
 
-\item \code{to_numeric}: The p-norm of \code{x}.
+\item \code{to_numeric(Pnorm)}: The p-norm of \code{x}.
 
-\item \code{validate_args}: Check that the arguments are valid.
+\item \code{validate_args(Pnorm)}: Check that the arguments are valid.
 
-\item \code{sign_from_args}: The atom is positive.
+\item \code{sign_from_args(Pnorm)}: The atom is positive.
 
-\item \code{is_atom_convex}: The atom is convex if \eqn{p \geq 1}.
+\item \code{is_atom_convex(Pnorm)}: The atom is convex if \eqn{p \geq 1}.
 
-\item \code{is_atom_concave}: The atom is concave if \eqn{p < 1}.
+\item \code{is_atom_concave(Pnorm)}: The atom is concave if \eqn{p < 1}.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Pnorm)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Pnorm)}: Is the atom log-log concave?
 
-\item \code{is_incr}: The atom is weakly increasing if \eqn{p < 1} or \eqn{p > 1} and \code{x} is positive.
+\item \code{is_incr(Pnorm)}: The atom is weakly increasing if \eqn{p < 1} or \eqn{p > 1} and \code{x} is positive.
 
-\item \code{is_decr}: The atom is weakly decreasing if \eqn{p > 1} and \code{x} is negative.
+\item \code{is_decr(Pnorm)}: The atom is weakly decreasing if \eqn{p > 1} and \code{x} is negative.
 
-\item \code{is_pwl}: The atom is not piecewise linear unless \eqn{p = 1} or \eqn{p = \infty}.
+\item \code{is_pwl(Pnorm)}: The atom is not piecewise linear unless \eqn{p = 1} or \eqn{p = \infty}.
 
-\item \code{get_data}: Returns \code{list(p, axis)}.
+\item \code{get_data(Pnorm)}: Returns \code{list(p, axis)}.
 
-\item \code{name}: The name and arguments of the atom.
+\item \code{name(Pnorm)}: The name and arguments of the atom.
 
-\item \code{.domain}: Returns constraints describing the domain of the node
+\item \code{.domain(Pnorm)}: Returns constraints describing the domain of the node
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(Pnorm)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.column_grad}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+\item \code{.column_grad(Pnorm)}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Power-class.Rd
+++ b/man/Power-class.Rd
@@ -105,39 +105,39 @@ For \eqn{p > 1, p \neq 2,4,8,\ldots} and \eqn{f(x) = }
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Throw an error if the power is negative and cannot be handled.
+\item \code{to_numeric(Power)}: Throw an error if the power is negative and cannot be handled.
 
-\item \code{sign_from_args}: The sign of the atom.
+\item \code{sign_from_args(Power)}: The sign of the atom.
 
-\item \code{is_atom_convex}: Is \eqn{p \leq 0} or \eqn{p \geq 1}?
+\item \code{is_atom_convex(Power)}: Is \eqn{p \leq 0} or \eqn{p \geq 1}?
 
-\item \code{is_atom_concave}: Is \eqn{p \geq 0} or \eqn{p \leq 1}?
+\item \code{is_atom_concave(Power)}: Is \eqn{p \geq 0} or \eqn{p \leq 1}?
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Power)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Power)}: Is the atom log-log concave?
 
-\item \code{is_constant}: A logical value indicating whether the atom is constant.
+\item \code{is_constant(Power)}: A logical value indicating whether the atom is constant.
 
-\item \code{is_incr}: A logical value indicating whether the atom is weakly increasing.
+\item \code{is_incr(Power)}: A logical value indicating whether the atom is weakly increasing.
 
-\item \code{is_decr}: A logical value indicating whether the atom is weakly decreasing.
+\item \code{is_decr(Power)}: A logical value indicating whether the atom is weakly decreasing.
 
-\item \code{is_quadratic}: A logical value indicating whether the atom is quadratic.
+\item \code{is_quadratic(Power)}: A logical value indicating whether the atom is quadratic.
 
-\item \code{is_qpwa}: A logical value indicating whether the atom is quadratic of piecewise affine.
+\item \code{is_qpwa(Power)}: A logical value indicating whether the atom is quadratic of piecewise affine.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(Power)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
 
-\item \code{.domain}: Returns constraints describng the domain of the node
+\item \code{.domain(Power)}: Returns constraints describng the domain of the node
 
-\item \code{get_data}: A list containing the output of \code{pow_low, pow_mid}, or \code{pow_high} depending on the input power.
+\item \code{get_data(Power)}: A list containing the output of \code{pow_low, pow_mid}, or \code{pow_high} depending on the input power.
 
-\item \code{copy}: Returns a shallow  copy of the power atom
+\item \code{copy(Power)}: Returns a shallow  copy of the power atom
 
-\item \code{name}: Returns the expression in string form.
+\item \code{name(Power)}: Returns the expression in string form.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Problem-class.Rd
+++ b/man/Problem-class.Rd
@@ -99,53 +99,53 @@ This class represents a convex optimization problem.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{objective}: The objective of the problem.
+\item \code{objective(Problem)}: The objective of the problem.
 
-\item \code{objective<-}: Set the value of the problem objective.
+\item \code{objective(Problem) <- value}: Set the value of the problem objective.
 
-\item \code{constraints}: A list of the constraints of the problem.
+\item \code{constraints(Problem)}: A list of the constraints of the problem.
 
-\item \code{constraints<-}: Set the value of the problem constraints.
+\item \code{constraints(Problem) <- value}: Set the value of the problem constraints.
 
-\item \code{value}: The value from the last time the problem was solved (or NA if not solved).
+\item \code{value(Problem)}: The value from the last time the problem was solved (or NA if not solved).
 
-\item \code{value<-}: Set the value of the optimal objective.
+\item \code{value(Problem) <- value}: Set the value of the optimal objective.
 
-\item \code{status}: The status from the last time the problem was solved.
+\item \code{status(Problem)}: The status from the last time the problem was solved.
 
-\item \code{is_dcp}: A logical value indicating whether the problem statisfies DCP rules.
+\item \code{is_dcp(Problem)}: A logical value indicating whether the problem statisfies DCP rules.
 
-\item \code{is_dgp}: A logical value indicating whether the problem statisfies DGP rules.
+\item \code{is_dgp(Problem)}: A logical value indicating whether the problem statisfies DGP rules.
 
-\item \code{is_qp}: A logical value indicating whether the problem is a quadratic program.
+\item \code{is_qp(Problem)}: A logical value indicating whether the problem is a quadratic program.
 
-\item \code{canonicalize}: The graph implementation of the problem.
+\item \code{canonicalize(Problem)}: The graph implementation of the problem.
 
-\item \code{is_mixed_integer}: logical value indicating whether the problem is a mixed integer program.
+\item \code{is_mixed_integer(Problem)}: logical value indicating whether the problem is a mixed integer program.
 
-\item \code{variables}: List of \linkS4class{Variable} objects in the problem.
+\item \code{variables(Problem)}: List of \linkS4class{Variable} objects in the problem.
 
-\item \code{parameters}: List of \linkS4class{Parameter} objects in the problem.
+\item \code{parameters(Problem)}: List of \linkS4class{Parameter} objects in the problem.
 
-\item \code{constants}: List of \linkS4class{Constant} objects in the problem.
+\item \code{constants(Problem)}: List of \linkS4class{Constant} objects in the problem.
 
-\item \code{atoms}: List of \linkS4class{Atom} objects in the problem.
+\item \code{atoms(Problem)}: List of \linkS4class{Atom} objects in the problem.
 
-\item \code{size_metrics}: Information about the size of the problem.
+\item \code{size_metrics(Problem)}: Information about the size of the problem.
 
-\item \code{solver_stats}: Additional information returned by the solver.
+\item \code{solver_stats(Problem)}: Additional information returned by the solver.
 
-\item \code{solver_stats<-}: Set the additional information returned by the solver in the problem.
+\item \code{solver_stats(Problem) <- value}: Set the additional information returned by the solver in the problem.
 
-\item \code{get_problem_data}: Get the problem data passed to the specified solver.
+\item \code{get_problem_data(object = Problem, solver = character, gp = logical)}: Get the problem data passed to the specified solver.
 
-\item \code{get_problem_data}: Get the problem data passed to the specified solver.
+\item \code{get_problem_data(object = Problem, solver = character, gp = missing)}: Get the problem data passed to the specified solver.
 
-\item \code{unpack_results}: Parses the output from a solver and updates the problem state, including the status,
+\item \code{unpack_results(Problem)}: Parses the output from a solver and updates the problem state, including the status,
 objective value, and values of the primal and dual variables.
 Assumes the results are from the given solver.
-}}
 
+}}
 \section{Slots}{
 
 \describe{

--- a/man/ProdEntries-class.Rd
+++ b/man/ProdEntries-class.Rd
@@ -59,27 +59,27 @@ The product of the entries in an expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The product of all the entries.
+\item \code{to_numeric(ProdEntries)}: The product of all the entries.
 
-\item \code{sign_from_args}: Returns the sign (is positive, is negative) of the atom.
+\item \code{sign_from_args(ProdEntries)}: Returns the sign (is positive, is negative) of the atom.
 
-\item \code{is_atom_convex}: Is the atom convex?
+\item \code{is_atom_convex(ProdEntries)}: Is the atom convex?
 
-\item \code{is_atom_concave}: Is the atom concave?
+\item \code{is_atom_concave(ProdEntries)}: Is the atom concave?
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(ProdEntries)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: is the atom log-log concave?
+\item \code{is_atom_log_log_concave(ProdEntries)}: is the atom log-log concave?
 
-\item \code{is_incr}: Is the atom weakly increasing in the argument \code{idx}?
+\item \code{is_incr(ProdEntries)}: Is the atom weakly increasing in the argument \code{idx}?
 
-\item \code{is_decr}: Is the atom weakly decreasing in the argument \code{idx}?
+\item \code{is_decr(ProdEntries)}: Is the atom weakly decreasing in the argument \code{idx}?
 
-\item \code{.column_grad}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
+\item \code{.column_grad(ProdEntries)}: Gives the (sub/super)gradient of the atom w.r.t. each column variable
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(ProdEntries)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Promote-class.Rd
+++ b/man/Promote-class.Rd
@@ -50,21 +50,21 @@ This class represents the promotion of a scalar expression into a vector/matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Promotes the value to the new dimensions.
+\item \code{to_numeric(Promote)}: Promotes the value to the new dimensions.
 
-\item \code{is_symmetric}: Is the expression symmetric?
+\item \code{is_symmetric(Promote)}: Is the expression symmetric?
 
-\item \code{dim_from_args}: Returns the (row, col) dimensions of the expression.
+\item \code{dim_from_args(Promote)}: Returns the (row, col) dimensions of the expression.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Promote)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Promote)}: Is the atom log-log concave?
 
-\item \code{get_data}: Returns information needed to reconstruct the expression besides the args.
+\item \code{get_data(Promote)}: Returns information needed to reconstruct the expression besides the args.
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(Promote)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/QpSolver-class.Rd
+++ b/man/QpSolver-class.Rd
@@ -21,8 +21,8 @@ A QP solver interface.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{accepts}: Is this a QP problem?
+\item \code{accepts(object = QpSolver, problem = Problem)}: Is this a QP problem?
 
-\item \code{perform}: Constructs a QP problem data stored in a list
+\item \code{perform(object = QpSolver, problem = Problem)}: Constructs a QP problem data stored in a list
+
 }}
-

--- a/man/QuadForm-class.Rd
+++ b/man/QuadForm-class.Rd
@@ -70,37 +70,37 @@ This class represents the quadratic form \eqn{x^T P x}
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The name and arguments of the atom.
+\item \code{name(QuadForm)}: The name and arguments of the atom.
 
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(QuadForm)}: Does the atom handle complex numbers?
 
-\item \code{to_numeric}: Returns the quadratic form.
+\item \code{to_numeric(QuadForm)}: Returns the quadratic form.
 
-\item \code{validate_args}: Checks the dimensions of the arguments.
+\item \code{validate_args(QuadForm)}: Checks the dimensions of the arguments.
 
-\item \code{sign_from_args}: Returns the sign (is positive, is negative) of the atom.
+\item \code{sign_from_args(QuadForm)}: Returns the sign (is positive, is negative) of the atom.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(QuadForm)}: The dimensions of the atom.
 
-\item \code{is_atom_convex}: Is the atom convex?
+\item \code{is_atom_convex(QuadForm)}: Is the atom convex?
 
-\item \code{is_atom_concave}: Is the atom concave?
+\item \code{is_atom_concave(QuadForm)}: Is the atom concave?
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(QuadForm)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(QuadForm)}: Is the atom log-log concave?
 
-\item \code{is_incr}: Is the atom weakly increasing in the argument \code{idx}?
+\item \code{is_incr(QuadForm)}: Is the atom weakly increasing in the argument \code{idx}?
 
-\item \code{is_decr}: Is the atom weakly decreasing in the argument \code{idx}?
+\item \code{is_decr(QuadForm)}: Is the atom weakly decreasing in the argument \code{idx}?
 
-\item \code{is_quadratic}: Is the atom quadratic?
+\item \code{is_quadratic(QuadForm)}: Is the atom quadratic?
 
-\item \code{is_pwl}: Is the atom piecewise linear?
+\item \code{is_pwl(QuadForm)}: Is the atom piecewise linear?
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(QuadForm)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/QuadOverLin-class.Rd
+++ b/man/QuadOverLin-class.Rd
@@ -70,37 +70,37 @@ This class represents the sum of squared entries in X divided by a scalar y, \eq
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(QuadOverLin)}: Does the atom handle complex numbers?
 
-\item \code{to_numeric}: The sum of the entries of \code{x} squared over \code{y}.
+\item \code{to_numeric(QuadOverLin)}: The sum of the entries of \code{x} squared over \code{y}.
 
-\item \code{validate_args}: Check the dimensions of the arguments.
+\item \code{validate_args(QuadOverLin)}: Check the dimensions of the arguments.
 
-\item \code{dim_from_args}: The atom is a scalar.
+\item \code{dim_from_args(QuadOverLin)}: The atom is a scalar.
 
-\item \code{sign_from_args}: The atom is positive.
+\item \code{sign_from_args(QuadOverLin)}: The atom is positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(QuadOverLin)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(QuadOverLin)}: The atom is not concave.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(QuadOverLin)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(QuadOverLin)}: Is the atom log-log concave?
 
-\item \code{is_incr}: A logical value indicating whether the atom is weakly increasing in argument \code{idx}.
+\item \code{is_incr(QuadOverLin)}: A logical value indicating whether the atom is weakly increasing in argument \code{idx}.
 
-\item \code{is_decr}: A logical value indicating whether the atom is weakly decreasing in argument \code{idx}.
+\item \code{is_decr(QuadOverLin)}: A logical value indicating whether the atom is weakly decreasing in argument \code{idx}.
 
-\item \code{is_quadratic}: Quadratic if \code{x} is affine and \code{y} is constant.
+\item \code{is_quadratic(QuadOverLin)}: Quadratic if \code{x} is affine and \code{y} is constant.
 
-\item \code{is_qpwa}: Quadratic of piecewise affine if \code{x} is piecewise linear and \code{y} is constant.
+\item \code{is_qpwa(QuadOverLin)}: Quadratic of piecewise affine if \code{x} is piecewise linear and \code{y} is constant.
 
-\item \code{.domain}: Returns constraints describing the domain of the node
+\item \code{.domain(QuadOverLin)}: Returns constraints describing the domain of the node
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(QuadOverLin)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Real-class.Rd
+++ b/man/Real-class.Rd
@@ -36,17 +36,17 @@ This class represents the real part of an expression.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The imaginary part of the given value.
+\item \code{to_numeric(Real)}: The imaginary part of the given value.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(Real)}: The dimensions of the atom.
 
-\item \code{is_imag}: Is the atom imaginary?
+\item \code{is_imag(Real)}: Is the atom imaginary?
 
-\item \code{is_complex}: Is the atom complex valued?
+\item \code{is_complex(Real)}: Is the atom complex valued?
 
-\item \code{is_symmetric}: Is the atom symmetric?
+\item \code{is_symmetric(Real)}: Is the atom symmetric?
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Reduction-class.Rd
+++ b/man/Reduction-class.Rd
@@ -45,14 +45,14 @@ of provenance.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{accepts}: States whether the reduction accepts a problem.
+\item \code{accepts(object = Reduction, problem = Problem)}: States whether the reduction accepts a problem.
 
-\item \code{reduce}: Reduces the owned problem to an equivalent problem.
+\item \code{reduce(Reduction)}: Reduces the owned problem to an equivalent problem.
 
-\item \code{retrieve}: Retrieves a solution to the owned problem.
+\item \code{retrieve(object = Reduction, solution = Solution)}: Retrieves a solution to the owned problem.
 
-\item \code{perform}: Performs the reduction on a problem and returns an equivalent problem.
+\item \code{perform(object = Reduction, problem = Problem)}: Performs the reduction on a problem and returns an equivalent problem.
 
-\item \code{invert}: Returns a solution to the original problem given the inverse data.
+\item \code{invert(object = Reduction, solution = Solution, inverse_data = list)}: Returns a solution to the original problem given the inverse data.
+
 }}
-

--- a/man/ReductionSolver-class.Rd
+++ b/man/ReductionSolver-class.Rd
@@ -86,18 +86,18 @@ The ReductionSolver class.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(ReductionSolver)}: Can the solver handle mixed-integer programs?
 
-\item \code{name}: Returns the name of the solver
+\item \code{name(ReductionSolver)}: Returns the name of the solver
 
-\item \code{import_solver}: Imports the solver
+\item \code{import_solver(ReductionSolver)}: Imports the solver
 
-\item \code{is_installed}: Is the solver installed?
+\item \code{is_installed(ReductionSolver)}: Is the solver installed?
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(ReductionSolver)}: Solve a problem represented by data returned from apply.
 
-\item \code{reduction_solve}: Solve a problem represented by data returned from apply.
+\item \code{reduction_solve(object = ReductionSolver, problem = ANY)}: Solve a problem represented by data returned from apply.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(ECOS)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/Reshape-class.Rd
+++ b/man/Reshape-class.Rd
@@ -51,21 +51,21 @@ then unvectorizes it into the new dimensions. Entries are stored in column-major
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Reshape the value into the specified dimensions.
+\item \code{to_numeric(Reshape)}: Reshape the value into the specified dimensions.
 
-\item \code{validate_args}: Check the new shape has the same number of entries as the old.
+\item \code{validate_args(Reshape)}: Check the new shape has the same number of entries as the old.
 
-\item \code{dim_from_args}: The \code{c(rows, cols)} dimensions of the new expression.
+\item \code{dim_from_args(Reshape)}: The \code{c(rows, cols)} dimensions of the new expression.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Reshape)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Reshape)}: Is the atom log-log concave?
 
-\item \code{get_data}: Returns a list containing the new shape.
+\item \code{get_data(Reshape)}: Returns a list containing the new shape.
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(Reshape)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/SCS-class.Rd
+++ b/man/SCS-class.Rd
@@ -81,20 +81,20 @@ An interface for the SCS solver
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{mip_capable}: Can the solver handle mixed-integer programs?
+\item \code{mip_capable(SCS)}: Can the solver handle mixed-integer programs?
 
-\item \code{status_map}: Converts status returned by SCS solver to its respective CVXPY status.
+\item \code{status_map(SCS)}: Converts status returned by SCS solver to its respective CVXPY status.
 
-\item \code{name}: Returns the name of the solver
+\item \code{name(SCS)}: Returns the name of the solver
 
-\item \code{import_solver}: Imports the solver
+\item \code{import_solver(SCS)}: Imports the solver
 
-\item \code{reduction_format_constr}: Return a linear operator to multiply by PSD constraint coefficients.
+\item \code{reduction_format_constr(SCS)}: Return a linear operator to multiply by PSD constraint coefficients.
 
-\item \code{perform}: Returns a new problem and data for inverting the new solution
+\item \code{perform(object = SCS, problem = Problem)}: Returns a new problem and data for inverting the new solution
 
-\item \code{invert}: Returns the solution to the original problem given the inverse_data.
+\item \code{invert(object = SCS, solution = list, inverse_data = list)}: Returns the solution to the original problem given the inverse_data.
 
-\item \code{solve_via_data}: Solve a problem represented by data returned from apply.
+\item \code{solve_via_data(SCS)}: Solve a problem represented by data returned from apply.
+
 }}
-

--- a/man/SOC-class.Rd
+++ b/man/SOC-class.Rd
@@ -63,25 +63,25 @@ This class represents a second-order cone constraint, i.e. \eqn{\|x\|_2 \leq t}.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{residual}: The residual of the second-order constraint.
+\item \code{residual(SOC)}: The residual of the second-order constraint.
 
-\item \code{get_data}: Information needed to reconstruct the object aside from the args.
+\item \code{get_data(SOC)}: Information needed to reconstruct the object aside from the args.
 
-\item \code{format_constr}: Format SOC constraints as inequalities for the solver.
+\item \code{format_constr(SOC)}: Format SOC constraints as inequalities for the solver.
 
-\item \code{num_cones}: The number of elementwise cones.
+\item \code{num_cones(SOC)}: The number of elementwise cones.
 
-\item \code{size}: The number of entries in the combined cones.
+\item \code{size(SOC)}: The number of entries in the combined cones.
 
-\item \code{cone_sizes}: The dimensions of the second-order cones.
+\item \code{cone_sizes(SOC)}: The dimensions of the second-order cones.
 
-\item \code{is_dcp}: An SOC constraint is DCP if each of its arguments is affine.
+\item \code{is_dcp(SOC)}: An SOC constraint is DCP if each of its arguments is affine.
 
-\item \code{is_dgp}: Is the constraint DGP?
+\item \code{is_dgp(SOC)}: Is the constraint DGP?
 
-\item \code{canonicalize}: The canonicalization of the constraint.
+\item \code{canonicalize(SOC)}: The canonicalization of the constraint.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/SOCAxis-class.Rd
+++ b/man/SOCAxis-class.Rd
@@ -49,15 +49,15 @@ It Assumes \eqn{t} is a vector the same length as \eqn{X}'s rows (columns) for a
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{format_constr}: Format SOC constraints as inequalities for the solver.
+\item \code{format_constr(SOCAxis)}: Format SOC constraints as inequalities for the solver.
 
-\item \code{num_cones}: The number of elementwise cones.
+\item \code{num_cones(SOCAxis)}: The number of elementwise cones.
 
-\item \code{cone_sizes}: The dimensions of a single cone.
+\item \code{cone_sizes(SOCAxis)}: The dimensions of a single cone.
 
-\item \code{size}: The dimensions of the (elementwise) second-order cones.
+\item \code{size(SOCAxis)}: The dimensions of the (elementwise) second-order cones.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/SigmaMax-class.Rd
+++ b/man/SigmaMax-class.Rd
@@ -50,25 +50,25 @@ The maximum singular value of a matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The largest singular value of \code{A}.
+\item \code{to_numeric(SigmaMax)}: The largest singular value of \code{A}.
 
-\item \code{allow_complex}: Does the atom handle complex numbers?
+\item \code{allow_complex(SigmaMax)}: Does the atom handle complex numbers?
 
-\item \code{dim_from_args}: The atom is a scalar.
+\item \code{dim_from_args(SigmaMax)}: The atom is a scalar.
 
-\item \code{sign_from_args}: The atom is positive.
+\item \code{sign_from_args(SigmaMax)}: The atom is positive.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(SigmaMax)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is concave.
+\item \code{is_atom_concave(SigmaMax)}: The atom is concave.
 
-\item \code{is_incr}: The atom is not monotonic in any argument.
+\item \code{is_incr(SigmaMax)}: The atom is not monotonic in any argument.
 
-\item \code{is_decr}: The atom is not monotonic in any argument.
+\item \code{is_decr(SigmaMax)}: The atom is not monotonic in any argument.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(SigmaMax)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/SolvingChain-class.Rd
+++ b/man/SolvingChain-class.Rd
@@ -64,11 +64,11 @@ This class represents a reduction chain that ends with a solver.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{prepend}: Create and return a new SolvingChain by concatenating chain with this instance.
+\item \code{prepend(object = SolvingChain, chain = Chain)}: Create and return a new SolvingChain by concatenating chain with this instance.
 
-\item \code{reduction_solve}: Applies each reduction in the chain to the problem, solves it,
+\item \code{reduction_solve(object = SolvingChain, problem = Problem)}: Applies each reduction in the chain to the problem, solves it,
 and then inverts the chain to return a solution of the supplied problem.
 
-\item \code{reduction_solve_via_data}: Solves the problem using the data output by the an apply invocation.
-}}
+\item \code{reduction_solve_via_data(SolvingChain)}: Solves the problem using the data output by the an apply invocation.
 
+}}

--- a/man/SpecialIndex-class.Rd
+++ b/man/SpecialIndex-class.Rd
@@ -63,17 +63,17 @@ This class represents indexing using logical indexing or a list of indices into 
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: Returns the index in string form.
+\item \code{name(SpecialIndex)}: Returns the index in string form.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(SpecialIndex)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(SpecialIndex)}: Is the atom log-log concave?
 
-\item \code{get_data}: A list containing \code{key}.
+\item \code{get_data(SpecialIndex)}: A list containing \code{key}.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(SpecialIndex)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/SumEntries-class.Rd
+++ b/man/SumEntries-class.Rd
@@ -43,15 +43,15 @@ This class represents the sum of all entries in a vector or matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Sum the entries along the specified axis.
+\item \code{to_numeric(SumEntries)}: Sum the entries along the specified axis.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(SumEntries)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(SumEntries)}: Is the atom log-log concave?
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(SumEntries)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/SumLargest-class.Rd
+++ b/man/SumLargest-class.Rd
@@ -55,27 +55,27 @@ The sum of the largest k values of a matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The sum of the \code{k} largest entries of the vector or matrix.
+\item \code{to_numeric(SumLargest)}: The sum of the \code{k} largest entries of the vector or matrix.
 
-\item \code{validate_args}: Check that \code{k} is a positive integer.
+\item \code{validate_args(SumLargest)}: Check that \code{k} is a positive integer.
 
-\item \code{dim_from_args}: The atom is a scalar.
+\item \code{dim_from_args(SumLargest)}: The atom is a scalar.
 
-\item \code{sign_from_args}: The sign of the atom.
+\item \code{sign_from_args(SumLargest)}: The sign of the atom.
 
-\item \code{is_atom_convex}: The atom is convex.
+\item \code{is_atom_convex(SumLargest)}: The atom is convex.
 
-\item \code{is_atom_concave}: The atom is not concave.
+\item \code{is_atom_concave(SumLargest)}: The atom is not concave.
 
-\item \code{is_incr}: The atom is weakly increasing in every argument.
+\item \code{is_incr(SumLargest)}: The atom is weakly increasing in every argument.
 
-\item \code{is_decr}: The atom is not weakly decreasing in any argument.
+\item \code{is_decr(SumLargest)}: The atom is not weakly decreasing in any argument.
 
-\item \code{get_data}: A list containing \code{k}.
+\item \code{get_data(SumLargest)}: A list containing \code{k}.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(SumLargest)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/SymbolicQuadForm-class.Rd
+++ b/man/SymbolicQuadForm-class.Rd
@@ -54,25 +54,25 @@ The SymbolicQuadForm class.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(SymbolicQuadForm)}: The dimensions of the atom.
 
-\item \code{sign_from_args}: The sign (is positive, is negative) of the atom.
+\item \code{sign_from_args(SymbolicQuadForm)}: The sign (is positive, is negative) of the atom.
 
-\item \code{get_data}: The original expression.
+\item \code{get_data(SymbolicQuadForm)}: The original expression.
 
-\item \code{is_atom_convex}: Is the original expression convex?
+\item \code{is_atom_convex(SymbolicQuadForm)}: Is the original expression convex?
 
-\item \code{is_atom_concave}: Is the original expression concave?
+\item \code{is_atom_concave(SymbolicQuadForm)}: Is the original expression concave?
 
-\item \code{is_incr}: Is the original expression weakly increasing in argument \code{idx}?
+\item \code{is_incr(SymbolicQuadForm)}: Is the original expression weakly increasing in argument \code{idx}?
 
-\item \code{is_decr}: Is the original expression weakly decreasing in argument \code{idx}?
+\item \code{is_decr(SymbolicQuadForm)}: Is the original expression weakly decreasing in argument \code{idx}?
 
-\item \code{is_quadratic}: The atom is quadratic.
+\item \code{is_quadratic(SymbolicQuadForm)}: The atom is quadratic.
 
-\item \code{.grad}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+\item \code{.grad(SymbolicQuadForm)}: Gives the (sub/super)gradient of the atom w.r.t. each variable
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Trace-class.Rd
+++ b/man/Trace-class.Rd
@@ -45,19 +45,19 @@ This class represents the sum of the diagonal entries in a matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Sum the diagonal entries.
+\item \code{to_numeric(Trace)}: Sum the diagonal entries.
 
-\item \code{validate_args}: Check the argument is a square matrix.
+\item \code{validate_args(Trace)}: Check the argument is a square matrix.
 
-\item \code{dim_from_args}: The atom is a scalar.
+\item \code{dim_from_args(Trace)}: The atom is a scalar.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Trace)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Trace)}: Is the atom log-log concave?
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(Trace)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Transpose-class.Rd
+++ b/man/Transpose-class.Rd
@@ -47,20 +47,20 @@ This class represents the matrix transpose.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: The transpose of the given value.
+\item \code{to_numeric(Transpose)}: The transpose of the given value.
 
-\item \code{is_symmetric}: Is the expression symmetric?
+\item \code{is_symmetric(Transpose)}: Is the expression symmetric?
 
-\item \code{is_hermitian}: Is the expression hermitian?
+\item \code{is_hermitian(Transpose)}: Is the expression hermitian?
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(Transpose)}: The dimensions of the atom.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Transpose)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Transpose)}: Is the atom log-log concave?
 
-\item \code{get_data}: Returns the axes for transposition.
+\item \code{get_data(Transpose)}: Returns the axes for transposition.
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(Transpose)}: The graph implementation of the atom.
+
 }}
-

--- a/man/UnaryOperator-class.Rd
+++ b/man/UnaryOperator-class.Rd
@@ -22,11 +22,11 @@ This base class represents expressions involving unary operators.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: Returns the expression in string form.
+\item \code{name(UnaryOperator)}: Returns the expression in string form.
 
-\item \code{to_numeric}: Applies the unary operator to the value.
+\item \code{to_numeric(UnaryOperator)}: Applies the unary operator to the value.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/UpperTri-class.Rd
+++ b/man/UpperTri-class.Rd
@@ -45,19 +45,19 @@ The vectorized strictly upper triagonal entries of a matrix.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Vectorize the upper triagonal entries.
+\item \code{to_numeric(UpperTri)}: Vectorize the upper triagonal entries.
 
-\item \code{validate_args}: Check the argument is a square matrix.
+\item \code{validate_args(UpperTri)}: Check the argument is a square matrix.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(UpperTri)}: The dimensions of the atom.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(UpperTri)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(UpperTri)}: Is the atom log-log concave?
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(UpperTri)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/VStack-class.Rd
+++ b/man/VStack-class.Rd
@@ -45,19 +45,19 @@ Vertical concatenation of values.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Vertically concatenate the values using \code{rbind}.
+\item \code{to_numeric(VStack)}: Vertically concatenate the values using \code{rbind}.
 
-\item \code{validate_args}: Check all arguments have the same width.
+\item \code{validate_args(VStack)}: Check all arguments have the same width.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(VStack)}: The dimensions of the atom.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(VStack)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(VStack)}: Is the atom log-log concave?
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(VStack)}: The graph implementation of the atom.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Variable-class.Rd
+++ b/man/Variable-class.Rd
@@ -43,17 +43,17 @@ This class represents an optimization variable.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The name of the variable.
+\item \code{name(Variable)}: The name of the variable.
 
-\item \code{value}: Get the value of the variable.
+\item \code{value(Variable)}: Get the value of the variable.
 
-\item \code{grad}: The sub/super-gradient of the variable represented as a sparse matrix.
+\item \code{grad(Variable)}: The sub/super-gradient of the variable represented as a sparse matrix.
 
-\item \code{variables}: Returns itself as a variable.
+\item \code{variables(Variable)}: Returns itself as a variable.
 
-\item \code{canonicalize}: The canonical form of the variable.
+\item \code{canonicalize(Variable)}: The canonical form of the variable.
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Wrap-class.Rd
+++ b/man/Wrap-class.Rd
@@ -37,14 +37,14 @@ This virtual class represents a no-op wrapper to assert properties.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{to_numeric}: Returns the input value.
+\item \code{to_numeric(Wrap)}: Returns the input value.
 
-\item \code{dim_from_args}: The dimensions of the atom.
+\item \code{dim_from_args(Wrap)}: The dimensions of the atom.
 
-\item \code{is_atom_log_log_convex}: Is the atom log-log convex?
+\item \code{is_atom_log_log_convex(Wrap)}: Is the atom log-log convex?
 
-\item \code{is_atom_log_log_concave}: Is the atom log-log concave?
+\item \code{is_atom_log_log_concave(Wrap)}: Is the atom log-log concave?
 
-\item \code{graph_implementation}: The graph implementation of the atom.
+\item \code{graph_implementation(Wrap)}: The graph implementation of the atom.
+
 }}
-

--- a/man/ZeroConstraint-class.Rd
+++ b/man/ZeroConstraint-class.Rd
@@ -32,16 +32,16 @@ The ZeroConstraint class
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{name}: The string representation of the constraint.
+\item \code{name(ZeroConstraint)}: The string representation of the constraint.
 
-\item \code{dim}: The dimensions of the constrained expression.
+\item \code{dim(ZeroConstraint)}: The dimensions of the constrained expression.
 
-\item \code{is_dcp}: Is the constraint DCP?
+\item \code{is_dcp(ZeroConstraint)}: Is the constraint DCP?
 
-\item \code{is_dgp}: Is the constraint DGP?
+\item \code{is_dgp(ZeroConstraint)}: Is the constraint DGP?
 
-\item \code{residual}: The residual of a constraint
+\item \code{residual(ZeroConstraint)}: The residual of a constraint
 
-\item \code{canonicalize}: The graph implementation of the object.
+\item \code{canonicalize(ZeroConstraint)}: The graph implementation of the object.
+
 }}
-

--- a/man/installed_solvers.Rd
+++ b/man/installed_solvers.Rd
@@ -29,10 +29,10 @@ account.
 }
 \section{Functions}{
 \itemize{
-\item \code{add_to_solver_blacklist}: Add to solver blacklist, useful for temporarily disabling a solver
+\item \code{add_to_solver_blacklist()}: Add to solver blacklist, useful for temporarily disabling a solver
 
-\item \code{remove_from_solver_blacklist}: Remove solvers from blacklist
+\item \code{remove_from_solver_blacklist()}: Remove solvers from blacklist
 
-\item \code{set_solver_blacklist}: Set solver blacklist to a value
+\item \code{set_solver_blacklist()}: Set solver blacklist to a value
+
 }}
-

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // build_matrix_0
 SEXP build_matrix_0(SEXP xp, Rcpp::IntegerVector v);
 RcppExport SEXP _CVXR_build_matrix_0(SEXP xpSEXP, SEXP vSEXP) {


### PR DESCRIPTION
- Fixes for new Matrix version.
- Fixed all use of class equality checks (`class(obj) == "foo"` or `class(obj) %in% c("foo", "bar")`) using `inherits(...)` instead. 