### PR TITLE
implement ignore_dcp

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -914,7 +914,10 @@ setGeneric("solver_stats<-", function(object, value) { standardGeneric("solver_s
 #' data[["G"]]
 #' @rdname get_problem_data
 #' @export
-setGeneric("get_problem_data", function(object, solver, gp) { standardGeneric("get_problem_data") })
+setGeneric("get_problem_data",
+  function(object, solver, ignore_dcp = FALSE, gp = FALSE) { standardGeneric("get_problem_data") },
+  signature = c("object", "solver")
+)
 
 #'
 #' Solve a DCP Problem
@@ -1173,7 +1176,7 @@ setGeneric("canonicalize_expr", function(object, expr, args) { standardGeneric("
 setGeneric("stuffed_objective", function(object, problem, extractor) { standardGeneric("stuffed_objective") })
 setGeneric("prepend", function(object, chain) { standardGeneric("prepend") })
 setGeneric("group_coeff_offset", function(object, problem, constraints, exp_cone_order) { standardGeneric("group_coeff_offset") })
-setGeneric("construct_intermediate_chain", function(problem, candidates, gp) { standardGeneric("construct_intermediate_chain") })
+setGeneric("construct_intermediate_chain", function(problem, candidates, ignore_dcp, gp) { standardGeneric("construct_intermediate_chain") })
 setGeneric("solve_via_data", function(object, data, warm_start, verbose, feastol, reltol, abstol, num_iter, solver_opts, solver_cache) { standardGeneric("solve_via_data") })
 setGeneric("unpack_problem", function(object, solution) { standardGeneric("unpack_problem") })
 setGeneric("unpack_results", function(object, solution, chain, inverse_data) { standardGeneric("unpack_results") })

--- a/R/problem.R
+++ b/R/problem.R
@@ -578,8 +578,8 @@ setMethod("solver_stats<-", "Problem", function(object, value) {
 #' @param solver A string indicating the solver that the problem data is for. Call \code{installed_solvers()} to see all available.
 #' @param gp A logical value indicating whether the problem is a geometric program.
 #' @describeIn Problem Get the problem data passed to the specified solver.
-setMethod("get_problem_data", signature(object = "Problem", solver = "character", gp = "logical"), function(object, solver, gp) {
-  object <- .construct_chains(object, solver = solver, gp = gp)
+setMethod("get_problem_data", signature(object = "Problem", solver = "character"), function(object, solver, ignore_dcp, gp) {
+  object <- .construct_chains(object, solver = solver, ignore_dcp = ignore_dcp, gp = gp)
 
   tmp <- perform(object@.solving_chain, object@.intermediate_problem)
   object@.solving_chain <- tmp[[1]]
@@ -635,21 +635,13 @@ setMethod("get_problem_data", signature(object = "Problem", solver = "character"
   return(candidates)
 }
 
-#'
-#' @param object A \linkS4class{Problem} class.
-#' @param solver A string indicating the solver that the problem data is for. Call \code{installed_solvers()} to see all available.
-#' @param gp Is the problem a geometric problem?
-#' @describeIn Problem Get the problem data passed to the specified solver.
-setMethod("get_problem_data", signature(object = "Problem", solver = "character", gp = "missing"), function(object, solver, gp) {
-  get_problem_data(object, solver, gp = FALSE)
-})
 
-.construct_chains <- function(object, solver = NA, gp = FALSE) {
+.construct_chains <- function(object, solver = NA, ignore_dcp = FALSE, gp = FALSE) {
   chain_key <- list(solver, gp)
 
   if(!identical(chain_key, object@.cached_chain_key)) {
     candidate_solvers <- .find_candidate_solvers(object, solver = solver, gp = gp)
-    object@.intermediate_chain <- construct_intermediate_chain(object, candidate_solvers, gp = gp)
+    object@.intermediate_chain <- construct_intermediate_chain(object, candidate_solvers, ignore_dcp = ignore_dcp, gp = gp)
     tmp <- perform(object@.intermediate_chain, object)
     object@.intermediate_chain <- tmp[[1]]
     object@.intermediate_problem <- tmp[[2]]
@@ -668,7 +660,7 @@ setMethod("psolve", "Problem", function(object, solver = NA, ignore_dcp = FALSE,
                                         parallel = FALSE, gp = FALSE, feastol = NULL, reltol = NULL, abstol = NULL, num_iter = NULL,  ...) {
   if(parallel)
     stop("Unimplemented")
-  object <- .construct_chains(object, solver = solver, gp = gp)
+  object <- .construct_chains(object, solver = solver, ignore_dcp = ignore_dcp, gp = gp)
   tmp <- perform(object@.solving_chain, object@.intermediate_problem)
   object@.solving_chain <- tmp[[1]]
   data <- tmp[[2]]

--- a/R/reduction_solvers.R
+++ b/R/reduction_solvers.R
@@ -287,7 +287,7 @@ setMethod("reduction_solve_via_data", "SolvingChain", function(object, problem, 
 #' @param candidates A list of candidate solvers.
 #' @param gp A logical value indicating whether the problem is a geometric program.
 #' @return A \linkS4class{Chain} object that can be used to convert the problem to an intermediate form.
-setMethod("construct_intermediate_chain", signature(problem = "Problem", candidates = "list"), function(problem, candidates, gp = FALSE) {
+setMethod("construct_intermediate_chain", signature(problem = "Problem", candidates = "list"), function(problem, candidates, ignore_dcp = FALSE, gp = FALSE) {
   reductions <- list()
   if(length(variables(problem)) == 0)
     return(Chain(reductions = reductions))
@@ -298,22 +298,24 @@ setMethod("construct_intermediate_chain", signature(problem = "Problem", candida
   if(gp)
     reductions <- c(reductions, Dgp2Dcp())
 
-  if(!gp) {
-      if (!is_dcp(problem)) {
-          err_msg  <- "Problem does not follow DCP rules."
-          if (is_dgp(problem)) {
-              err_msg  <- paste(err_msg, "However, the problem does follow DGP rules. Consider calling this function with gp = TRUE")
-          }
-          stop(err_msg)
-      }
-  } else {
-      if(!is_dgp(problem)) {
-          err_msg  <- "Problem does not follow DGP rules."
-          if (is_dcp(problem)) {
-              err_msg  <- paste(err_msg, "However, the problem does follow DCP rules. Consider calling this function with gp = FALSE")
-          }
-          stop(err_msg)
-      }
+  if (!ignore_dcp) {
+    if(!gp) {
+        if (!is_dcp(problem)) {
+            err_msg  <- "Problem does not follow DCP rules."
+            if (is_dgp(problem)) {
+                err_msg  <- paste(err_msg, "However, the problem does follow DGP rules. Consider calling this function with gp = TRUE")
+            }
+            stop(err_msg)
+        }
+    } else {
+        if(!is_dgp(problem)) {
+            err_msg  <- "Problem does not follow DGP rules."
+            if (is_dcp(problem)) {
+                err_msg  <- paste(err_msg, "However, the problem does follow DCP rules. Consider calling this function with gp = FALSE")
+            }
+            stop(err_msg)
+        }
+    }
   }
 
   # Dcp2Cone and Qp2SymbolicQp require problems to minimize their objectives.


### PR DESCRIPTION
Going along very similar lines as https://github.com/cvxpy/cvxpy/pull/1669

Currently ignore_dcp is an argument in public apis, but there's no active code in CVXR that actually does anything with this argument. This PR implements ignore_dcp functionality, and skips is_dcp checks if set to TRUE. This is sometimes useful when is_dcp is very slow, and user is confident the problem is dcp and wishes to skip the check to speed up CVXR compile time.

